### PR TITLE
fix(config): 将旧版 DashScope 模型迁移至 ZenMux 提供商

### DIFF
--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -202,20 +202,19 @@ export interface DailySummaryFact {
 }
 
 export const AVAILABLE_MODELS: ModelRef[] = [
-  // { provider: "zenmux", model: "deepseek/deepseek-v3.2" },
-  { provider: "dashscope", model: "deepseek-v3.2" },
-  { provider: "dashscope", model: "qwen-plus-2025-12-01" },
-  { provider: "dashscope", model: "Moonshot-Kimi-K2-Instruct" },
-  { provider: "dashscope", model: "qwen3-vl-235b-a22b-instruct" },
-  { provider: "dashscope", model: "qwen3-max" },
+  { provider: "zenmux", model: "deepseek/deepseek-v3.2" },
+  // { provider: "dashscope", model: "deepseek-v3.2" },
+  // { provider: "dashscope", model: "qwen-plus-2025-12-01" },
+  // { provider: "dashscope", model: "Moonshot-Kimi-K2-Instruct" },
+  // { provider: "dashscope", model: "qwen3-vl-235b-a22b-instruct" },
+  // { provider: "dashscope", model: "qwen3-max" },
 
   { provider: "zenmux", model: "google/gemini-3-flash-preview" },
   // { provider: "openrouter", model: "minimax/minimax-m2.1" },
-  // { provider: "zenmux", model: "moonshotai/kimi-k2-0905" },
-  // { provider: "zenmux", model: "z-ai/glm-4.7-flashx" },
-  // { provider: "zenmux", model: "qwen/qwen3-max" },
+  { provider: "zenmux", model: "moonshotai/kimi-k2-0905" },
+  { provider: "zenmux", model: "z-ai/glm-4.7-flashx" },
+  { provider: "zenmux", model: "qwen/qwen3-max" },
   { provider: "zenmux", model: "volcengine/doubao-seed-1.8" },
-  // { provider: "zenmux", model: "google/gemini-2.5-flash-lite-preview-09-2025" },
   // {provider:"zenmux",model:"openai/gpt-5.2-chat"},
   // {provider:"zenmux",model:"anthropic/claude-sonnet-4.5"}
 ];


### PR DESCRIPTION
## 问题描述
在游戏中，当 AI 角色（如狼人、女巫）执行行动时，会触发 500 Internal Server Error 报错。

issue: https://github.com/oil-oil/wolfcha/issues/4

- 报错信息： `{"error":"DASHSCOPE_API_KEY not configured on server"}`
- 原因：`game.ts` 中的 `AVAILABLE_MODELS` 列表包含了一些配置为 `provider: "dashscope"` 的模型。然而，项目目前的架构已转向统一使用 ZenMux 网关，.env.example 和文档中均未提供 DASHSCOPE_API_KEY 的配置项，导致服务端在尝试直接调用 DashScope 接口时因缺少 Key 而报错。

## 解决方案
- 修改了 `src/types/game.ts`，注释掉了旧版直接调用 DashScope 的模型配置。
- 启用/迁移了对应的模型使用 provider: "zenmux"。
- 确保所有模型请求都路由到配置好的 ZenMux 网关，从而避免因缺少遗留的 API Key 而导致的 500 错误。

## 验证
验证了 AI 角色现在可以正常执行行动（投票/使用技能），不再触发 500 错误。