### PR TITLE
fix(game): 修复警徽平票 PK 阶段无法发言的问题

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1440,7 +1440,7 @@ export default function Home() {
                       displayedText={displayedText}
                       isTyping={isTyping}
                       onAdvanceDialogue={handleAdvanceDialogue}
-                      isHumanTurn={(gameState.phase === "DAY_SPEECH" || gameState.phase === "DAY_LAST_WORDS" || gameState.phase === "DAY_BADGE_SPEECH") && gameState.currentSpeakerSeat === humanPlayer?.seat && !waitingForNextRound}
+                      isHumanTurn={(gameState.phase === "DAY_SPEECH" || gameState.phase === "DAY_LAST_WORDS" || gameState.phase === "DAY_BADGE_SPEECH" || gameState.phase === "DAY_PK_SPEECH") && gameState.currentSpeakerSeat === humanPlayer?.seat && !waitingForNextRound}
                       waitingForNextRound={waitingForNextRound}
                       tutorialHelpLabel={tutorialHelpLabel}
                       showTutorialHelp={showTutorialHelp}


### PR DESCRIPTION
## 修复警徽平票 PK 阶段无法发言的问题

### 问题描述
在警长竞选环节出现平票并进入 PK 发言阶段 (`DAY_PK_SPEECH`) 时，虽然轮到了人类玩家发言，但界面下方未显示输入框，导致玩家无法进行发言操作。

### 原因分析
`DialogArea` 组件的输入框显示逻辑依赖于 `isHumanTurn` 状态。在 `src/app/page.tsx` 中计算该状态时，判断条件仅包含了普通发言 (`DAY_SPEECH`)、遗言 (`DAY_LAST_WORDS`) 和警上发言 (`DAY_BADGE_SPEECH`)，遗漏了警徽 PK 发言 (`DAY_PK_SPEECH`) 阶段。

### 解决方法
在 `src/app/page.tsx` 的 `isHumanTurn` 判断逻辑中补充了 `gameState.phase === "DAY_PK_SPEECH"` 条件，确保在该阶段轮到玩家时能正确唤起输入 UI。

### 截图
**Before:**
<img width="1764" height="1068" alt="image" src="https://github.com/user-attachments/assets/e3995974-9f8f-413a-8891-5cd5ac031b7a" />

**After:**
<img width="1620" height="974" alt="image" src="https://github.com/user-attachments/assets/404afd91-cdde-483d-a913-e04bb240eded" />
