### PR TITLE
fix(llm): preserve spaces in streaming English dialogue

### DIFF
--- a/src/components/game/DialogArea.tsx
+++ b/src/components/game/DialogArea.tsx
@@ -937,7 +937,9 @@ export function DialogArea({
     }
   };
 
-  const baseDialogueText = (displayedText || currentSpeaker?.text || "").trim();
+  const baseDialogueText = currentDialogue?.isStreaming
+    ? displayedText
+    : (displayedText || currentSpeaker?.text || "");
   // When human has voted in badge election, show "你已经投票给 x 号" instead of "点击头像投票选警徽"
   const humanBadgeVote = humanPlayer ? gameState.badge.votes[humanPlayer.playerId] : undefined;
   const dialogueText =
@@ -950,7 +952,7 @@ export function DialogArea({
           return t("dialog.alreadyVotedFor", { seat: humanBadgeVote + 1, name: vp?.displayName || "" });
         })()
       : baseDialogueText;
-  const shouldShowDialogue = waitingForNextRound || dialogueText.length > 0;
+  const shouldShowDialogue = waitingForNextRound || dialogueText.trim().length > 0;
   const isNightActionPhase = [
     "NIGHT_GUARD_ACTION",
     "NIGHT_WOLF_ACTION",

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -234,6 +234,10 @@ const REASONING_TAG_PATTERN = REASONING_TAG_NAMES.join("|");
 
 /** Remove model reasoning artifacts that may be embedded in assistant content. */
 export function stripReasoningArtifacts(text: string): string {
+  return stripReasoningArtifactsPreserveWhitespace(text).trim();
+}
+
+function stripReasoningArtifactsPreserveWhitespace(text: string): string {
   if (!text) return text;
 
   return text
@@ -244,8 +248,7 @@ export function stripReasoningArtifacts(text: string): string {
       ),
       ""
     )
-    .replace(new RegExp(`<\\s*\\/?\\s*(${REASONING_TAG_PATTERN})\\b[^>]*>`, "gi"), "")
-    .trim();
+    .replace(new RegExp(`<\\s*\\/?\\s*(${REASONING_TAG_PATTERN})\\b[^>]*>`, "gi"), "");
 }
 
 function findReasoningEnd(text: string): { end: number } | null {
@@ -706,7 +709,7 @@ export async function* generateCompletionStream(
         const delta = json.choices?.[0]?.delta?.content;
         if (delta) {
           if (thinkStripped) {
-            const cleaned = stripReasoningArtifacts(delta);
+            const cleaned = stripReasoningArtifactsPreserveWhitespace(delta);
             totalOutputChars += cleaned.length;
             if (cleaned) yield cleaned;
           } else {
@@ -714,7 +717,7 @@ export async function* generateCompletionStream(
             const reasoningEnd = findReasoningEnd(thinkBuffer);
             if (reasoningEnd) {
               // 找到 </think>，丢弃之前内容，从之后开始输出
-              const after = stripReasoningArtifacts(thinkBuffer.slice(reasoningEnd.end).replace(/^\n+/, ""));
+              const after = stripReasoningArtifactsPreserveWhitespace(thinkBuffer.slice(reasoningEnd.end).replace(/^\n+/, ""));
               thinkStripped = true;
               thinkBuffer = "";
               if (after) {
@@ -724,7 +727,7 @@ export async function* generateCompletionStream(
             } else if (!couldBeReasoningStart(thinkBuffer) && thinkBuffer.length >= 1) {
               // 确认不是 <think> 块，直接透传
               thinkStripped = true;
-              const cleaned = stripReasoningArtifacts(thinkBuffer);
+              const cleaned = stripReasoningArtifactsPreserveWhitespace(thinkBuffer);
               totalOutputChars += cleaned.length;
               if (cleaned) yield cleaned;
               thinkBuffer = "";


### PR DESCRIPTION
## Summary
- Preserve leading whitespace in streaming LLM deltas so English tokens keep spaces between words.
- Keep final reasoning-artifact cleanup trimmed for non-streaming/full responses.
- Preserve streaming dialogue text in the UI while still trimming only for empty-content checks.

## Changes
- src/lib/llm.ts
- src/components/game/DialogArea.tsx

## Verification
- pnpm exec tsc --noEmit --pretty false

🤖 Shipped via git-ship