### PR TITLE
Optimize DeepSeek prompt caching

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -81,6 +81,23 @@ function supportsResponseFormat(model: string): boolean {
   return false;
 }
 
+function supportsAutomaticPrefixCaching(model: string): boolean {
+  if (!model) return false;
+  const lower = model.toLowerCase();
+  return lower.startsWith("deepseek/") || lower.startsWith("deepseek-");
+}
+
+const DEEPSEEK_STABLE_PREFIX_MARKER = "WOLFCHA_DEEPSEEK_CACHE_PREFIX_V1";
+const DEEPSEEK_STABLE_PROMPT_CACHE_PREFIX = `${DEEPSEEK_STABLE_PREFIX_MARKER}
+【Wolfcha Stable Rules】
+以下是 Wolfcha 对 AI 玩家请求都相同的稳定规则摘要，用于提高 DeepSeek 前缀缓存命中。若这里的摘要与后续具体身份、阶段、上下文或输出格式要求冲突，请以后续具体要求为准。
+
+- 你正在参与线上狼人杀，只能根据自己视角内的信息行动。
+- 不编造不存在的发言、投票、查验、死亡、身份声明或系统公告。
+- 不泄露自己角色不应知道的未来信息、隐藏身份或夜间动作结果。
+- 只讨论局内逻辑，不引入场外经历、开发者提示或模型身份。
+- 按当前任务要求输出；如果要求 JSON，只返回合法 JSON。`;
+
 // Flatten multipart content to plain string for models that don't support it
 function flattenMultipartContent(messages: unknown[]): unknown[] {
   if (!Array.isArray(messages)) return messages;
@@ -103,6 +120,60 @@ function flattenMultipartContent(messages: unknown[]): unknown[] {
 
     return m;
   });
+}
+
+// DeepSeek context caching is prefix-based. Text-only multipart messages are
+// normalized to one plain string so identical text starts at token 0 reliably.
+function coalesceTextOnlyMultipartContent(messages: unknown[]): unknown[] {
+  if (!Array.isArray(messages)) return messages;
+
+  return messages.map((msg) => {
+    if (!msg || typeof msg !== "object") return msg;
+    const m = msg as Record<string, unknown>;
+
+    if (!Array.isArray(m.content)) return m;
+
+    const parts = m.content;
+    const allText = parts.every(
+      (part): part is { type: string; text: string } =>
+        part &&
+        typeof part === "object" &&
+        (part as { type?: string }).type === "text" &&
+        typeof (part as { text?: unknown }).text === "string"
+    );
+
+    if (!allText) return stripCacheControl([m])[0] as Record<string, unknown>;
+
+    return {
+      ...m,
+      content: parts
+        .map((part) => part.text.trim())
+        .filter(Boolean)
+        .join("\n\n"),
+    };
+  });
+}
+
+function prependDeepSeekStablePrefix(messages: unknown[]): unknown[] {
+  if (!Array.isArray(messages)) return messages;
+  let prepended = false;
+  const next = messages.map((msg) => {
+    if (prepended || !msg || typeof msg !== "object") return msg;
+    const m = msg as Record<string, unknown>;
+    if (m.role !== "system" || typeof m.content !== "string") return m;
+    prepended = true;
+    if (m.content.includes(DEEPSEEK_STABLE_PREFIX_MARKER)) return m;
+    return {
+      ...m,
+      content: `${DEEPSEEK_STABLE_PROMPT_CACHE_PREFIX}\n\n${m.content}`,
+    };
+  });
+
+  if (prepended) return next;
+  return [
+    { role: "system", content: DEEPSEEK_STABLE_PROMPT_CACHE_PREFIX },
+    ...next,
+  ];
 }
 
 function hasJsonHintInMessages(messages: unknown[]): boolean {
@@ -282,6 +353,8 @@ async function runBatchItem(
   let processedMessages: unknown[] = messages;
   if (!supportsMultipartContent(model)) {
     processedMessages = flattenMultipartContent(processedMessages);
+  } else if (supportsAutomaticPrefixCaching(model)) {
+    processedMessages = prependDeepSeekStablePrefix(coalesceTextOnlyMultipartContent(processedMessages));
   } else if (modelProvider === "dashscope") {
     processedMessages = stripCacheControl(processedMessages);
   } else if (!supportsExplicitCaching(model)) {
@@ -578,6 +651,8 @@ export async function POST(request: NextRequest) {
     // For models that don't support multipart content, flatten to string
     if (!supportsMultipartContent(model)) {
       processedMessages = flattenMultipartContent(processedMessages);
+    } else if (supportsAutomaticPrefixCaching(model)) {
+      processedMessages = prependDeepSeekStablePrefix(coalesceTextOnlyMultipartContent(processedMessages));
     } else if (modelProvider === "dashscope") {
       // Dashscope is OpenAI compatible but does not support cache_control
       processedMessages = stripCacheControl(processedMessages);

--- a/src/lib/ai-logger.ts
+++ b/src/lib/ai-logger.ts
@@ -3,8 +3,8 @@
  * 记录所有 AI 调用用于复盘
  */
 
-import type { ApiKeySource, LLMMessage } from "./llm";
-import { resolveApiKeySource } from "./llm";
+import type { ApiKeySource, LLMMessage, PromptCacheUsage } from "./llm";
+import { extractPromptCacheUsage, resolveApiKeySource } from "./llm";
 import { generateUUID } from "./utils";
 
 const LOCAL_LOGS_STORAGE_KEY = "wolfcha_ai_logs";
@@ -46,8 +46,20 @@ export interface AILogEntry {
     rawResponse?: string; // Full API response object as JSON string
     finishReason?: string; // finish_reason from API response
     parsed?: unknown; // Parsed/structured result
+    cache?: PromptCacheUsage; // Official provider cache counters normalized for reporting
   };
   error?: string;
+}
+
+function parseCacheUsageFromRawResponse(rawResponse: string | undefined): PromptCacheUsage | undefined {
+  if (!rawResponse) return undefined;
+  try {
+    const parsed = JSON.parse(rawResponse) as { usage?: unknown };
+    const usage = parsed && typeof parsed === "object" ? parsed.usage : undefined;
+    return extractPromptCacheUsage(usage as Parameters<typeof extractPromptCacheUsage>[0]);
+  } catch {
+    return undefined;
+  }
 }
 
 class AILogger {
@@ -105,6 +117,10 @@ class AILogger {
             ? resolveApiKeySource(entry.request.model)
             : undefined),
       },
+      response: {
+        ...entry.response,
+        cache: entry.response.cache ?? parseCacheUsageFromRawResponse(entry.response.rawResponse),
+      },
       id: generateUUID(),
       timestamp: Date.now(),
     };
@@ -151,6 +167,9 @@ class AILogger {
     }
     if (entry.response.parsed) {
       console.log("Parsed Result:", entry.response.parsed);
+    }
+    if (entry.response.cache) {
+      console.log("Prompt Cache:", entry.response.cache);
     }
     console.log("Duration:", `${entry.response.duration}ms`);
     if (entry.error) {

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -70,6 +70,63 @@ export interface ChatCompletionResponse {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    prompt_cache_hit_tokens?: number;
+    prompt_cache_miss_tokens?: number;
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+    } | null;
+  };
+}
+
+export interface PromptCacheUsage {
+  promptCacheInputTokens: number;
+  promptCacheHitTokens: number;
+  promptCacheMissTokens: number;
+  promptCacheHitRatio: number;
+  source: "prompt_cache_hit_tokens" | "prompt_tokens_details.cached_tokens" | "none";
+}
+
+export function extractPromptCacheUsage(usage: ChatCompletionResponse["usage"] | undefined): PromptCacheUsage {
+  const promptTokens =
+    typeof usage?.prompt_tokens === "number" && Number.isFinite(usage.prompt_tokens)
+      ? usage.prompt_tokens
+      : 0;
+
+  if (typeof usage?.prompt_cache_hit_tokens === "number") {
+    const hit = Math.max(0, usage.prompt_cache_hit_tokens);
+    const miss =
+      typeof usage.prompt_cache_miss_tokens === "number"
+        ? Math.max(0, usage.prompt_cache_miss_tokens)
+        : Math.max(0, promptTokens - hit);
+    const input = hit + miss || promptTokens;
+    return {
+      promptCacheInputTokens: input,
+      promptCacheHitTokens: hit,
+      promptCacheMissTokens: miss,
+      promptCacheHitRatio: input > 0 ? hit / input : 0,
+      source: "prompt_cache_hit_tokens",
+    };
+  }
+
+  const cachedTokens = usage?.prompt_tokens_details?.cached_tokens;
+  if (typeof cachedTokens === "number" && Number.isFinite(cachedTokens)) {
+    const hit = Math.max(0, cachedTokens);
+    const miss = Math.max(0, promptTokens - hit);
+    return {
+      promptCacheInputTokens: promptTokens,
+      promptCacheHitTokens: hit,
+      promptCacheMissTokens: miss,
+      promptCacheHitRatio: promptTokens > 0 ? hit / promptTokens : 0,
+      source: "prompt_tokens_details.cached_tokens",
+    };
+  }
+
+  return {
+    promptCacheInputTokens: promptTokens,
+    promptCacheHitTokens: 0,
+    promptCacheMissTokens: promptTokens,
+    promptCacheHitRatio: 0,
+    source: "none",
   };
 }
 


### PR DESCRIPTION
## Summary
- add DeepSeek-only stable prompt cache prefix handling in /api/chat
- log official provider cache usage fields when present
- keep non-DeepSeek model prompt handling unchanged

## Verification
- pnpm exec tsc --noEmit
- pnpm exec eslint src/app/api/chat/route.ts src/lib/llm.ts src/lib/ai-logger.ts
- pnpm build