### PR TITLE
fix(tokenpay): allow long character streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:single-player-context": "tsx --test src/lib/ai-logger.test.ts src/lib/game-master.badge-signup.test.ts src/lib/game-master.player-setup.test.ts src/lib/game-master.stream-logging.test.ts src/lib/speech-order.test.ts scripts/single-player-context-audit.test.ts src/lib/prompt-utils.test.ts src/hooks/useDialogueManager.test.ts",
     "audit:single-player-context": "tsx scripts/single-player-context-audit.ts",
     "audit:single-player-context:live": "node --env-file=.env.local --import tsx scripts/live-single-player-context-audit.ts",
+    "audit:character-generation:live": "node --env-file=.env.local --import tsx scripts/live-character-generation-audit.ts",
     "lint": "eslint",
     "test:tokenpay": "NODE_OPTIONS=--conditions=react-server tsx --test server/tokenpay-*.test.ts",
     "migrate:game-sessions-user-id": "node scripts/migrate-game-sessions-user-id.mjs"

--- a/scripts/live-character-generation-audit.ts
+++ b/scripts/live-character-generation-audit.ts
@@ -1,0 +1,238 @@
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import messages from "@/i18n/messages/zh.json";
+import { parseLLMJson } from "@/lib/llm-json";
+import { stripMarkdownCodeFences } from "@/lib/llm";
+
+const MODEL = "deepseek-v4-flash-0731";
+const PLAYER_COUNT = 9;
+const OUTPUT_PATH = path.resolve("dry-runs/live-character-generation-audit.json");
+
+type BaseProfile = {
+  displayName: string;
+  gender: "male" | "female";
+  age: number;
+  mbti: string;
+  basicInfo: string;
+};
+
+type ProviderCall = {
+  stage: "base" | "persona";
+  status: number;
+  durationMs: number;
+  headersMs: number;
+  firstContentMs: number | null;
+  maxReadGapMs: number;
+  outputChars: number;
+  finishReason: string | null;
+  usage: unknown;
+  responseHash: string;
+};
+
+const interpolate = (template: string, values: Record<string, string | number>) =>
+  template.replace(/\{(\w+)\}/g, (match, key: string) =>
+    Object.prototype.hasOwnProperty.call(values, key) ? String(values[key]) : match
+  );
+
+const scenario = {
+  title: "深夜便利店",
+  description: "一群刚下班的人在便利店休息区玩一局狼人杀。",
+  rolesHint: "普通上班族、夜班店员、学生和附近居民",
+};
+
+const basePrompt = interpolate(messages.characterGenerator.baseProfilesPrompt, {
+  count: PLAYER_COUNT,
+  ...scenario,
+});
+
+const providerUrl = () => {
+  const base = process.env.TOKENDANCE_BASE_URL?.trim().replace(/\/+$/, "");
+  if (!base || !process.env.TOKENDANCE_API_KEY) {
+    throw new Error("缺少 TOKENDANCE_API_KEY 或 TOKENDANCE_BASE_URL");
+  }
+  return `${base}/chat/completions`;
+};
+
+const digest = (content: string) => createHash("sha256").update(content).digest("hex");
+
+async function callProvider(
+  stage: ProviderCall["stage"],
+  prompt: string,
+  maxTokens: number,
+  stream: boolean,
+): Promise<{ content: string; record: ProviderCall }> {
+  const startedAt = Date.now();
+  const response = await fetch(providerUrl(), {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.TOKENDANCE_API_KEY}`,
+      "Content-Type": "application/json",
+      "X-App-Name": "Wolfcha",
+      "X-Site-URL": "https://www.wolf-cha.com",
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      messages: [{ role: "user", content: prompt }],
+      temperature: 0.9,
+      max_tokens: maxTokens,
+      thinking: { type: "disabled" },
+      ...(stream ? { stream: true } : {}),
+    }),
+  });
+  const headersMs = Date.now() - startedAt;
+
+  let content = "";
+  let finishReason: string | null = null;
+  let usage: unknown = null;
+  let firstContentMs: number | null = null;
+  let maxReadGapMs = 0;
+
+  if (stream) {
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("流式响应没有 body");
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let lastReadAt = Date.now();
+    while (true) {
+      const { done, value } = await reader.read();
+      const now = Date.now();
+      maxReadGapMs = Math.max(maxReadGapMs, now - lastReadAt);
+      lastReadAt = now;
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("data: ") || trimmed === "data: [DONE]") continue;
+        const payload = JSON.parse(trimmed.slice(6)) as {
+          choices?: Array<{ delta?: { content?: string }; finish_reason?: string | null }>;
+          usage?: unknown;
+        };
+        const delta = payload.choices?.[0]?.delta?.content ?? "";
+        if (delta && firstContentMs === null) firstContentMs = Date.now() - startedAt;
+        content += delta;
+        finishReason = payload.choices?.[0]?.finish_reason ?? finishReason;
+        usage = payload.usage ?? usage;
+      }
+    }
+  } else {
+    const payload = await response.json() as {
+      choices?: Array<{ message?: { content?: string }; finish_reason?: string | null }>;
+      usage?: unknown;
+    };
+    content = payload.choices?.[0]?.message?.content ?? "";
+    firstContentMs = content ? Date.now() - startedAt : null;
+    finishReason = payload.choices?.[0]?.finish_reason ?? null;
+    usage = payload.usage ?? null;
+  }
+
+  const record: ProviderCall = {
+    stage,
+    status: response.status,
+    durationMs: Date.now() - startedAt,
+    headersMs,
+    firstContentMs,
+    maxReadGapMs,
+    outputChars: content.length,
+    finishReason,
+    usage,
+    responseHash: digest(content),
+  };
+  if (!response.ok) {
+    throw new Error(`${stage} 请求失败：HTTP ${response.status}`);
+  }
+  return { content, record };
+}
+
+const buildPersonaPrompt = (profiles: BaseProfile[]) => {
+  const roster = profiles
+    .map((profile, index) => interpolate(messages.characterGenerator.rosterLine, {
+      index: index + 1,
+      name: profile.displayName,
+      gender: profile.gender,
+      age: profile.age,
+      basicInfo: profile.basicInfo,
+    }))
+    .join("\n");
+  const schema = profiles
+    .map((profile) =>
+      `  { "displayName": "${profile.displayName}", "persona": { "voiceRules": string[], "werewolfExperience": string, "vocabularyStyle": string, "reasoningStyle": string, "speechLengthHabit": string, "pressureStyle": string, "uncertaintyStyle": string, "mistakePattern": string, "wolfDeceptionStyle": string, "mbti": "${profile.mbti}", "gender": "${profile.gender}", "age": ${profile.age} }, "playerMind": { "courage": string, "memoryBias": string, "suspicionThreshold": string, "selfProtection": string, "logicDepth": string, "tablePresence": string } }`
+    )
+    .join(",\n");
+  return interpolate(messages.characterGenerator.fullPersonasPrompt, {
+    title: scenario.title,
+    description: scenario.description,
+    roster,
+    count: profiles.length,
+    schema,
+  });
+};
+
+async function main() {
+  const calls: ProviderCall[] = [];
+  const fixedProfiles: BaseProfile[] = [
+    { displayName: "张伟", gender: "male", age: 35, mbti: "ESTJ", basicInfo: "刚下夜班的出租车司机" },
+    { displayName: "林雨", gender: "female", age: 27, mbti: "ENFP", basicInfo: "互联网产品经理" },
+    { displayName: "周诚", gender: "male", age: 31, mbti: "ISTJ", basicInfo: "便利店夜班店员" },
+    { displayName: "陈曦", gender: "female", age: 24, mbti: "INFP", basicInfo: "准备考研的学生" },
+    { displayName: "王凯", gender: "male", age: 42, mbti: "ENTJ", basicInfo: "附近小公司的老板" },
+    { displayName: "赵宁", gender: "female", age: 38, mbti: "ISFJ", basicInfo: "社区医院护士" },
+    { displayName: "许峰", gender: "male", age: 29, mbti: "INTP", basicInfo: "自由职业程序员" },
+    { displayName: "唐悦", gender: "female", age: 33, mbti: "ESFP", basicInfo: "健身房教练" },
+    { displayName: "刘洋", gender: "male", age: 26, mbti: "ISFP", basicInfo: "刚结束排练的乐手" },
+  ];
+  let profiles = fixedProfiles;
+  if (process.env.CHARACTER_AUDIT_PERSONA_ONLY !== "true") {
+    const base = await callProvider(
+      "base",
+      `${basePrompt}\n\nRespond with valid JSON only. No markdown, no code blocks, just raw JSON.`,
+      Math.max(2400, PLAYER_COUNT * 350 + 600),
+      false,
+    );
+    calls.push(base.record);
+    const baseJson = parseLLMJson<{ profiles?: BaseProfile[] }>(stripMarkdownCodeFences(base.content));
+    profiles = baseJson?.profiles ?? [];
+  }
+  if (profiles.length !== PLAYER_COUNT) {
+    throw new Error(`基础档案数量错误：${profiles.length}/${PLAYER_COUNT}`);
+  }
+
+  const persona = await callProvider(
+    "persona",
+    buildPersonaPrompt(profiles),
+    Math.max(9000, PLAYER_COUNT * 1250 + 1800),
+    true,
+  );
+  calls.push(persona.record);
+  const personaJson = parseLLMJson<{ characters?: Array<{ displayName?: string }> }>(
+    stripMarkdownCodeFences(persona.content),
+  );
+  const characters = personaJson?.characters ?? [];
+  const expectedNames = profiles.map((profile) => profile.displayName);
+  const actualNames = characters.map((character) => character.displayName ?? "");
+  const checks = {
+    baseCount: profiles.length === PLAYER_COUNT,
+    personaJsonValid: personaJson !== null,
+    personaCount: characters.length === PLAYER_COUNT,
+    personaOrderMatches: JSON.stringify(actualNames) === JSON.stringify(expectedNames),
+  };
+
+  const report = {
+    generatedAt: new Date().toISOString(),
+    model: MODEL,
+    playerCount: PLAYER_COUNT,
+    calls,
+    checks,
+  };
+  await mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
+  await writeFile(OUTPUT_PATH, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  console.log(JSON.stringify(report, null, 2));
+  if (Object.values(checks).some((passed) => !passed)) process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/server/tokenpay-chat-stream-duration.test.ts
+++ b/server/tokenpay-chat-stream-duration.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const chatRouteSource = readFileSync("src/app/api/chat/route.ts", "utf8");
+
+test("聊天流函数时长覆盖完整角色生成的真实长输出", () => {
+  const match = chatRouteSource.match(/export const maxDuration\s*=\s*(\d+)/);
+  assert.ok(match, "聊天 Route 必须显式声明 Vercel maxDuration");
+  assert.ok(Number(match[1]) >= 300, "maxDuration 至少应为 300 秒，避免 60 秒截断流式 JSON");
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -17,6 +17,11 @@ import {
 } from "@/lib/tokenpay";
 import { Agent, setGlobalDispatcher } from "undici";
 
+// 9 人完整角色画像的正常流式输出实测可超过 80 秒。未启用 Fluid
+// Compute 的 Vercel 项目默认上限可能只有 60 秒，必须显式放宽；这只延长
+// HTTP 流的承载时间，不改变模型提示、输出内容或游戏逻辑。
+export const maxDuration = 300;
+
 // 将 undici 底层 TCP 连接超时从默认 10s 调高到 60s
 // 避免访问国内 API 网关（如 tokendance）时因建连慢而提前失败
 setGlobalDispatcher(new Agent({ connectTimeout: 60_000 }));


### PR DESCRIPTION
## 问题

线上 TokenPay 余额正常，但 9 人完整 persona 生成会在约 60 秒后被函数时长截断，角色 JSON 不完整，开局返回首页。

## 修复

- 为 `/api/chat` 显式声明 300 秒最大函数时长
- 新增长流时长回归测试
- 新增真实付费角色生成审计脚本，记录首包、最大空闲间隔、总时长、JSON 完整性和用量，不保存模型正文或密钥

## 验证

- TokenPay：40/40
- 单人上下文与随机座位：25/25
- ESLint：通过
- Next.js production build：通过
- 真实 TokenDance / DeepSeek：9 人 persona 两次分别 60.756s、82.390s，JSON 数量和顺序均正确