### PR TITLE
fix(credits): make game start consumption idempotent

### DIFF
--- a/server/credit-consume-route-contract.test.ts
+++ b/server/credit-consume-route-contract.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const routeSource = readFileSync(
+  join(process.cwd(), "src/app/api/credits/consume/route.ts"),
+  "utf8",
+);
+const hookSource = readFileSync(
+  join(process.cwd(), "src/hooks/useCredits.ts"),
+  "utf8",
+);
+const welcomeSource = readFileSync(
+  join(process.cwd(), "src/components/game/WelcomeScreen.tsx"),
+  "utf8",
+);
+
+test("扣费前强制校验幂等键，旧页面不会继续产生扣款", () => {
+  const requiredIndex = routeSource.indexOf('code: "idempotency_key_required"');
+  const firstMutationIndex = routeSource.indexOf("isDemoModeActiveServer()");
+
+  assert.ok(requiredIndex >= 0);
+  assert.ok(firstMutationIndex >= 0);
+  assert.ok(requiredIndex < firstMutationIndex);
+  assert.match(routeSource, /status:\s*428/);
+});
+
+test("所有开局会话分支都持久化请求身份，付费分支只调用 v2 RPC", () => {
+  assert.match(routeSource, /start_request_id:\s*options\.requestId/);
+  assert.match(routeSource, /start_request_fingerprint:\s*options\.requestFingerprint/);
+  assert.match(routeSource, /start_request_source:\s*options\.requestSource/);
+  assert.match(routeSource, /consume_credit_for_authorized_game_session_v2/);
+  assert.match(routeSource, /consume_spring_quota_for_authorized_game_session_v2/);
+  assert.doesNotMatch(
+    routeSource,
+    /supabaseAdmin\.rpc\(\s*["']consume_credit_for_authorized_game_session["']/,
+  );
+});
+
+test("并发幂等冲突在所有来源都统一映射为 409", () => {
+  assert.match(routeSource, /buildIdempotencyConflictResponse/);
+  assert.match(routeSource, /code:\s*"idempotency_conflict"/);
+  assert.match(routeSource, /status:\s*409/);
+  assert.ok(
+    (routeSource.match(/return buildIdempotencyConflictResponse\(user, payload, startRequestId\)/g) ?? [])
+      .length >= 3,
+  );
+});
+
+test("客户端持久化同一请求 ID，并在真实开局完成后才清除", () => {
+  assert.match(hookSource, /getOrCreateGameStartRequest/);
+  assert.match(hookSource, /"Idempotency-Key": startRequestId/);
+  assert.match(hookSource, /runGameStartRequestWithRetry/);
+  assert.match(welcomeSource, /!hasPendingGameStartRequest\(buildCreditConsumeOptions\(\)\)/);
+
+  const onStartIndex = welcomeSource.indexOf("await onStart(buildStartOptions(gameSessionId))");
+  const completeIndex = welcomeSource.indexOf("completeGameStartRequest(startRequestId)");
+  assert.ok(onStartIndex >= 0);
+  assert.ok(completeIndex > onStartIndex);
+});

--- a/server/credit-idempotency-contract.test.ts
+++ b/server/credit-idempotency-contract.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const migration = readFileSync(
+  join(
+    process.cwd(),
+    "supabase/migrations/20260901132040_idempotent_game_start_requests.sql",
+  ),
+  "utf8",
+).toLowerCase();
+
+function functionBody(name: string): string {
+  const start = migration.indexOf(`create or replace function public.${name}`);
+  assert.notEqual(start, -1, `${name} must be defined`);
+  const end = migration.indexOf("\n$$;", start);
+  assert.notEqual(end, -1, `${name} must have a complete plpgsql body`);
+  return migration.slice(start, end);
+}
+
+test("game_sessions 增加可空幂等列及同用户唯一键", () => {
+  assert.match(
+    migration,
+    /alter table public\.game_sessions[\s\S]*add column if not exists start_request_id uuid;/,
+  );
+  assert.match(
+    migration,
+    /alter table public\.game_sessions[\s\S]*add column if not exists start_request_fingerprint text;/,
+  );
+  assert.match(
+    migration,
+    /create unique index if not exists game_sessions_user_start_request_uidx[\s\S]*\(user_id, start_request_id\)[\s\S]*where start_request_id is not null/,
+  );
+  assert.match(
+    migration,
+    /add constraint game_sessions_start_request_source_check[\s\S]*start_request_source in \('demo', 'external', 'spring_quota', 'project_credit'\)/,
+  );
+  assert.match(
+    migration,
+    /add constraint game_sessions_start_request_fields_check[\s\S]*start_request_id is null[\s\S]*start_request_fingerprint is null[\s\S]*start_request_source is null[\s\S]*start_request_id is not null[\s\S]*start_request_fingerprint is not null[\s\S]*start_request_source is not null/,
+  );
+  assert.match(migration, /start_request_fingerprint ~ '\^\[0-9a-f\]\{64\}\$'/);
+  assert.match(migration, /if not exists \([\s\S]*pg_constraint[\s\S]*conname/);
+  assert.match(migration, /validate constraint game_sessions_start_request_fields_check/);
+});
+
+test("credit v2 先锁余额并重放，再检查余额和扣费", () => {
+  const body = functionBody("consume_credit_for_authorized_game_session_v2");
+  const lock = body.indexOf("from public.user_credits uc");
+  const replayLookup = body.indexOf("from public.game_sessions gs");
+  const replayReturn = body.indexOf("return query select v_session_id, v_credits, true");
+  const balanceCheck = body.indexOf("if v_credits <= 0");
+  const debit = body.indexOf("update public.user_credits");
+  const sessionInsert = body.indexOf("insert into public.game_sessions");
+
+  assert.ok(lock >= 0 && body.indexOf("for update", lock) > lock);
+  assert.ok(lock < replayLookup);
+  assert.ok(replayLookup < replayReturn);
+  assert.ok(replayReturn < balanceCheck);
+  assert.ok(balanceCheck < debit && debit < sessionInsert);
+  assert.match(body, /p_start_request_id uuid/);
+  assert.match(body, /p_start_request_fingerprint text/);
+  assert.match(body, /returns table\(session_id uuid, credits integer, replayed boolean\)/);
+  assert.match(body, /'project_credit'/);
+  assert.match(body, /v_existing_source is distinct from 'project_credit'/);
+  assert.match(body, /idempotency_conflict/);
+  assert.match(body, /replayed boolean/);
+  assert.match(body, /return query select v_session_id, v_credits, false/);
+});
+
+test("spring v2 在同一事务中扣 quota 并插入 session，且重放返回 quota 状态", () => {
+  const body = functionBody("consume_spring_quota_for_authorized_game_session_v2");
+  const quotaLock = body.indexOf("from public.campaign_daily_quota q");
+  const replayLookup = body.indexOf("from public.game_sessions gs");
+  const replayReturn = body.indexOf("v_expires_at,\n             true");
+  const expiryCheck = body.indexOf("if v_expires_at <= now()");
+  const quotaUpdate = body.indexOf("update public.campaign_daily_quota");
+  const sessionInsert = body.indexOf("insert into public.game_sessions");
+
+  assert.ok(quotaLock >= 0 && body.indexOf("for update", quotaLock) > quotaLock);
+  assert.ok(quotaLock < replayLookup && replayLookup < replayReturn);
+  assert.ok(replayReturn < expiryCheck);
+  assert.ok(expiryCheck < quotaUpdate && quotaUpdate < sessionInsert);
+  assert.match(body, /spring_quota_expired/);
+  assert.match(body, /insufficient_spring_quota/);
+  assert.match(
+    body,
+    /returns table\([\s\S]*session_id uuid,[\s\S]*granted_quota integer,[\s\S]*consumed_quota integer,[\s\S]*expires_at timestamptz,[\s\S]*replayed boolean[\s\S]*\)/,
+  );
+  assert.doesNotMatch(body, /remaining_quota/);
+  assert.match(body, /'spring_quota'/);
+  assert.match(body, /v_existing_source is distinct from 'spring_quota'/);
+  assert.match(body, /idempotency_conflict/);
+  assert.match(body, /return query[\s\S]*v_consumed_quota \+ 1[\s\S]*false/);
+});
+
+test("两个新 RPC 使用 security invoker 且只向 service_role 授权", () => {
+  const compactMigration = migration.replace(/\s+/g, " ");
+  for (const [name, signature] of [
+    [
+      "consume_credit_for_authorized_game_session_v2",
+      "uuid, integer, text, text, text, text, uuid, text",
+    ],
+    [
+      "consume_spring_quota_for_authorized_game_session_v2",
+      "uuid, text, date, integer, text, text, text, text, uuid, text",
+    ],
+  ]) {
+    const functionPattern = new RegExp(
+      `create or replace function public\\.${name}[\\s\\S]*?security invoker`,
+    );
+    assert.match(migration, functionPattern);
+    assert.doesNotMatch(
+      migration,
+      new RegExp(`create or replace function public\\.${name}[\\s\\S]*?security definer`),
+    );
+    const compactSignature = signature.replaceAll(", ", ", ");
+    assert.match(
+      compactMigration,
+      new RegExp(
+        `revoke all on function public\\.${name}\\( ${compactSignature} \\) from public, anon, authenticated`,
+      ),
+    );
+    assert.match(
+      compactMigration,
+      new RegExp(
+        `grant execute on function public\\.${name}\\( ${compactSignature} \\) to service_role`,
+      ),
+    );
+  }
+});
+
+test("迁移不替换或删除旧 credit RPC，并可重复执行", () => {
+  assert.doesNotMatch(
+    migration,
+    /(?:drop|create or replace) function public\.consume_credit_for_authorized_game_session\s*\(/,
+  );
+  assert.match(migration, /add column if not exists/);
+  assert.match(migration, /create or replace function public\.consume_credit_for_authorized_game_session_v2/);
+  assert.match(migration, /create or replace function public\.consume_spring_quota_for_authorized_game_session_v2/);
+});

--- a/src/app/api/credits/consume/route.ts
+++ b/src/app/api/credits/consume/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { createHash } from "node:crypto";
 import { supabaseAdmin, ensureAdminClient } from "@/lib/supabase-admin";
 import { isDemoModeActiveServer } from "@/lib/demo-config-server";
 import {
@@ -34,6 +35,24 @@ type AuthenticatedUser = {
   email?: string | null;
 };
 
+type StartRequestSource = "demo" | "external" | "spring_quota" | "project_credit";
+
+type ExistingGameStart = {
+  id: string;
+  start_request_fingerprint: string;
+  start_request_source: StartRequestSource;
+};
+
+const IDEMPOTENCY_KEY_HEADER = "idempotency-key";
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+class IdempotencyConflictError extends Error {
+  constructor() {
+    super("idempotency_conflict");
+    this.name = "IdempotencyConflictError";
+  }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -48,12 +67,113 @@ async function readPayload(request: Request): Promise<ConsumeCreditPayload> {
   }
 }
 
+function buildStartRequestFingerprint(
+  source: StartRequestSource,
+  payload: ConsumeCreditPayload,
+): string {
+  const normalized = JSON.stringify({
+    version: 1,
+    source,
+    playerCount: Math.floor(Number(payload.playerCount)),
+    difficulty: payload.difficulty?.trim() || null,
+    modelUsed: payload.modelUsed?.trim() || null,
+  });
+  return createHash("sha256").update(normalized).digest("hex");
+}
+
+async function readCurrentCredits(userId: string): Promise<number> {
+  const { data, error } = await supabaseAdmin
+    .from("user_credits")
+    .select("credits")
+    .eq("id", userId)
+    .single();
+  if (error || !data) throw new Error("Failed to read credits");
+  return (data as { credits: number }).credits;
+}
+
+async function findExistingGameStart(
+  userId: string,
+  requestId: string,
+): Promise<ExistingGameStart | null> {
+  const { data, error } = await supabaseAdmin
+    .from("game_sessions")
+    .select("id, start_request_fingerprint, start_request_source")
+    .eq("user_id", userId)
+    .eq("start_request_id", requestId)
+    .maybeSingle();
+  if (error) throw new Error("Failed to read game start request");
+  return (data as ExistingGameStart | null) ?? null;
+}
+
+function assertMatchingGameStart(
+  existing: ExistingGameStart,
+  payload: ConsumeCreditPayload,
+) {
+  const expected = buildStartRequestFingerprint(existing.start_request_source, payload);
+  if (existing.start_request_fingerprint !== expected) {
+    throw new IdempotencyConflictError();
+  }
+}
+
+async function buildExistingGameStartResponse(
+  user: AuthenticatedUser,
+  payload: ConsumeCreditPayload,
+  existing: ExistingGameStart,
+) {
+  assertMatchingGameStart(existing, payload);
+  const credits = await readCurrentCredits(user.id);
+  return NextResponse.json({
+    success: true,
+    credits,
+    bypassed: existing.start_request_source === "demo" || existing.start_request_source === "external",
+    usedTemporaryQuota: existing.start_request_source === "spring_quota",
+    sessionId: existing.id,
+    idempotentReplay: true,
+  });
+}
+
+async function buildIdempotencyConflictResponse(
+  user: AuthenticatedUser,
+  payload: ConsumeCreditPayload,
+  requestId: string,
+) {
+  try {
+    const existing = await findExistingGameStart(user.id, requestId);
+    if (existing) {
+      try {
+        return await buildExistingGameStartResponse(user, payload, existing);
+      } catch (error) {
+        if (!(error instanceof IdempotencyConflictError)) throw error;
+      }
+    }
+  } catch (error) {
+    console.error("[credits/consume] failed to recover idempotency conflict", error);
+    return NextResponse.json(
+      { error: "Failed to recover game start request" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(
+    { error: "Idempotency key conflicts with another game start", code: "idempotency_conflict" },
+    { status: 409 },
+  );
+}
+
 async function createGameSessionForConsume(
   user: AuthenticatedUser,
   payload: ConsumeCreditPayload,
-  options: { creditAuthorized: boolean; usedCustomKey: boolean }
-): Promise<string | null> {
-  if (!payload.createSession) return null;
+  options: {
+    creditAuthorized: boolean;
+    usedCustomKey: boolean;
+    requestId: string;
+    requestFingerprint: string;
+    requestSource: StartRequestSource;
+  }
+): Promise<{ sessionId: string | null; replayed: boolean; source: StartRequestSource }> {
+  if (!payload.createSession) {
+    return { sessionId: null, replayed: false, source: options.requestSource };
+  }
 
   const playerCount = Number(payload.playerCount);
   if (!Number.isFinite(playerCount) || playerCount <= 0) {
@@ -72,6 +192,9 @@ async function createGameSessionForConsume(
     user_email: payload.userEmail ?? user.email ?? null,
     region: payload.region || null,
     last_activity_at: nowIso,
+    start_request_id: options.requestId,
+    start_request_fingerprint: options.requestFingerprint,
+    start_request_source: options.requestSource,
   };
 
   const { data, error } = await supabaseAdmin
@@ -81,17 +204,34 @@ async function createGameSessionForConsume(
     .single();
 
   if (error || !data) {
+    if (error?.code === "23505") {
+      const existing = await findExistingGameStart(user.id, options.requestId);
+      if (existing) {
+        assertMatchingGameStart(existing, payload);
+        return {
+          sessionId: existing.id,
+          replayed: true,
+          source: existing.start_request_source,
+        };
+      }
+    }
     console.error("[credits/consume] failed to create game session", error);
     throw new Error("Failed to create game session");
   }
 
-  return (data as { id: string }).id;
+  return {
+    sessionId: (data as { id: string }).id,
+    replayed: false,
+    source: options.requestSource,
+  };
 }
 
 async function consumeCreditAndCreateSession(
   user: AuthenticatedUser,
-  payload: ConsumeCreditPayload
-): Promise<{ sessionId: string | null; credits: number }> {
+  payload: ConsumeCreditPayload,
+  requestId: string,
+  requestFingerprint: string,
+): Promise<{ sessionId: string | null; credits: number; replayed: boolean }> {
   const playerCount = Number(payload.playerCount);
   if (!payload.createSession) {
     throw new Error("Game session is required for project credits");
@@ -101,7 +241,7 @@ async function consumeCreditAndCreateSession(
   }
 
   const { data, error } = await supabaseAdmin.rpc(
-    "consume_credit_for_authorized_game_session" as never,
+    "consume_credit_for_authorized_game_session_v2" as never,
     {
       p_user_id: user.id,
       p_player_count: Math.floor(playerCount),
@@ -109,6 +249,8 @@ async function consumeCreditAndCreateSession(
       p_model_used: payload.modelUsed || null,
       p_user_email: payload.userEmail ?? user.email ?? null,
       p_region: payload.region || null,
+      p_start_request_id: requestId,
+      p_start_request_fingerprint: requestFingerprint,
     } as never
   );
 
@@ -116,11 +258,18 @@ async function consumeCreditAndCreateSession(
     if (error.message.includes("insufficient_credits")) {
       throw new Error("Insufficient credits");
     }
+    if (error.message.includes("idempotency_conflict")) {
+      throw new IdempotencyConflictError();
+    }
     console.error("[credits/consume] rpc failed", error);
     throw new Error("Failed to consume credit");
   }
 
-  const rows = data as unknown as Array<{ session_id: string; credits: number }>;
+  const rows = data as unknown as Array<{
+    session_id: string;
+    credits: number;
+    replayed: boolean;
+  }>;
   const row = rows[0];
   if (!row) {
     throw new Error("Failed to consume credit");
@@ -129,6 +278,7 @@ async function consumeCreditAndCreateSession(
   return {
     sessionId: row.session_id,
     credits: row.credits,
+    replayed: row.replayed === true,
   };
 }
 
@@ -155,6 +305,45 @@ export async function POST(request: Request) {
   }
 
   const payload = await readPayload(request);
+  if (payload.createSession !== true) {
+    return NextResponse.json(
+      { error: "Game session is required", code: "game_session_required" },
+      { status: 400 },
+    );
+  }
+
+  const startRequestId = request.headers.get(IDEMPOTENCY_KEY_HEADER)?.trim() || "";
+  if (!startRequestId) {
+    return NextResponse.json(
+      {
+        error: "Please refresh the page before starting a game",
+        code: "idempotency_key_required",
+      },
+      { status: 428 },
+    );
+  }
+  if (!UUID_PATTERN.test(startRequestId)) {
+    return NextResponse.json(
+      { error: "Invalid idempotency key", code: "invalid_idempotency_key" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const existing = await findExistingGameStart(user.id, startRequestId);
+    if (existing) {
+      return await buildExistingGameStartResponse(user, payload, existing);
+    }
+  } catch (error) {
+    if (error instanceof IdempotencyConflictError) {
+      return NextResponse.json(
+        { error: "Idempotency key conflicts with another game start", code: "idempotency_conflict" },
+        { status: 409 },
+      );
+    }
+    console.error("[credits/consume] failed to recover game start request", error);
+    return NextResponse.json({ error: "Failed to recover game start request" }, { status: 500 });
+  }
 
   // Demo mode: skip credit consumption entirely
   if (await isDemoModeActiveServer()) {
@@ -164,16 +353,31 @@ export async function POST(request: Request) {
       .eq("id", user.id)
       .single();
     const creditsRow = data as { credits: number } | null;
-    const sessionId = await createGameSessionForConsume(user, payload, {
-      creditAuthorized: false,
-      usedCustomKey: Boolean(payload.usedCustomKey),
-    });
+    const requestSource: StartRequestSource = "demo";
+    let session: Awaited<ReturnType<typeof createGameSessionForConsume>>;
+    try {
+      session = await createGameSessionForConsume(user, payload, {
+        creditAuthorized: false,
+        usedCustomKey: Boolean(payload.usedCustomKey),
+        requestId: startRequestId,
+        requestFingerprint: buildStartRequestFingerprint(requestSource, payload),
+        requestSource,
+      });
+    } catch (error) {
+      if (error instanceof IdempotencyConflictError) {
+        return buildIdempotencyConflictResponse(user, payload, startRequestId);
+      }
+      console.error("[credits/consume] demo session creation failed", error);
+      return NextResponse.json({ error: "Failed to create game session" }, { status: 500 });
+    }
     return NextResponse.json({
       success: true,
       credits: creditsRow?.credits ?? 0,
-      bypassed: true,
-      demoMode: true,
-      sessionId,
+      bypassed: session.source === "demo" || session.source === "external",
+      demoMode: session.source === "demo",
+      usedTemporaryQuota: session.source === "spring_quota",
+      sessionId: session.sessionId,
+      idempotentReplay: session.replayed,
     });
   }
 
@@ -241,17 +445,31 @@ export async function POST(request: Request) {
       .eq("id", user.id)
       .single();
     const creditsRow = data as { credits: number } | null;
-    const sessionId = await createGameSessionForConsume(user, payload, {
-      creditAuthorized: false,
-      usedCustomKey: true,
-    });
+    const requestSource: StartRequestSource = "external";
+    let session: Awaited<ReturnType<typeof createGameSessionForConsume>>;
+    try {
+      session = await createGameSessionForConsume(user, payload, {
+        creditAuthorized: false,
+        usedCustomKey: true,
+        requestId: startRequestId,
+        requestFingerprint: buildStartRequestFingerprint(requestSource, payload),
+        requestSource,
+      });
+    } catch (error) {
+      if (error instanceof IdempotencyConflictError) {
+        return buildIdempotencyConflictResponse(user, payload, startRequestId);
+      }
+      console.error("[credits/consume] external session creation failed", error);
+      return NextResponse.json({ error: "Failed to create game session" }, { status: 500 });
+    }
     return NextResponse.json({
       success: true,
       credits: creditsRow?.credits ?? 0,
-      bypassed: true,
-      usedTemporaryQuota: false,
+      bypassed: session.source === "demo" || session.source === "external",
+      usedTemporaryQuota: session.source === "spring_quota",
       campaign: buildCampaignPayload(campaignRow),
-      sessionId,
+      sessionId: session.sessionId,
+      idempotentReplay: session.replayed,
     });
   }
 
@@ -286,72 +504,82 @@ export async function POST(request: Request) {
   }
 
   if (springCampaignActive && quotaDate && campaignRow) {
-    let latestCampaignRow = campaignRow;
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      const remainingBefore = latestCampaignRow.granted_quota - latestCampaignRow.consumed_quota;
-      if (remainingBefore <= 0 || new Date(latestCampaignRow.expires_at) <= now) break;
+    const requestSource: StartRequestSource = "spring_quota";
+    const { data, error } = await supabaseAdmin.rpc(
+      "consume_spring_quota_for_authorized_game_session_v2" as never,
+      {
+        p_user_id: user.id,
+        p_campaign_code: SPRING_CAMPAIGN_CODE,
+        p_quota_date: quotaDate,
+        p_player_count: Math.floor(Number(payload.playerCount)),
+        p_difficulty: payload.difficulty || null,
+        p_model_used: payload.modelUsed || null,
+        p_user_email: payload.userEmail ?? user.email ?? null,
+        p_region: payload.region || null,
+        p_start_request_id: startRequestId,
+        p_start_request_fingerprint: buildStartRequestFingerprint(requestSource, payload),
+      } as never,
+    );
 
-      const nextConsumed = latestCampaignRow.consumed_quota + 1;
-      const { data: updatedCampaignData, error: campaignUpdateError } = await supabaseAdmin
-        .from("campaign_daily_quota")
-        .update({
-          consumed_quota: nextConsumed,
-          updated_at: new Date().toISOString(),
-        } as never)
-        .eq("user_id", user.id)
-        .eq("campaign_code", SPRING_CAMPAIGN_CODE)
-        .eq("quota_date", quotaDate)
-        .eq("consumed_quota", latestCampaignRow.consumed_quota)
-        .select("granted_quota, consumed_quota, expires_at")
-        .single();
-
-      if (!campaignUpdateError && updatedCampaignData) {
-        const updatedCampaignRow = updatedCampaignData as CampaignQuotaRow;
-        const { data: creditsData } = await supabaseAdmin
-          .from("user_credits")
-          .select("credits")
-          .eq("id", user.id)
-          .single();
-        const creditsRow = creditsData as { credits: number } | null;
-        const sessionId = await createGameSessionForConsume(user, payload, {
-          creditAuthorized: true,
-          usedCustomKey: false,
-        });
-
-        return NextResponse.json({
-          success: true,
-          credits: creditsRow?.credits ?? 0,
-          usedTemporaryQuota: true,
-          campaign: buildCampaignPayload(updatedCampaignRow),
-          sessionId,
-        });
+    if (!error) {
+      const row = (data as unknown as Array<{
+        session_id: string;
+        granted_quota: number;
+        consumed_quota: number;
+        expires_at: string;
+        replayed: boolean;
+      }>)[0];
+      if (!row) {
+        return NextResponse.json({ error: "Failed to consume temporary quota" }, { status: 500 });
       }
-
-      const { data: refreshedCampaignData } = await supabaseAdmin
-        .from("campaign_daily_quota")
-        .select("granted_quota, consumed_quota, expires_at")
-        .eq("user_id", user.id)
-        .eq("campaign_code", SPRING_CAMPAIGN_CODE)
-        .eq("quota_date", quotaDate)
-        .maybeSingle();
-      if (!refreshedCampaignData) {
-        break;
-      }
-      latestCampaignRow = refreshedCampaignData as CampaignQuotaRow;
+      const updatedCampaignRow: CampaignQuotaRow = {
+        granted_quota: row.granted_quota,
+        consumed_quota: row.consumed_quota,
+        expires_at: row.expires_at,
+      };
+      return NextResponse.json({
+        success: true,
+        credits: await readCurrentCredits(user.id),
+        usedTemporaryQuota: true,
+        campaign: buildCampaignPayload(updatedCampaignRow),
+        sessionId: row.session_id,
+        idempotentReplay: row.replayed === true,
+      });
     }
-    campaignRow = latestCampaignRow;
+
+    if (error.message.includes("idempotency_conflict")) {
+      return buildIdempotencyConflictResponse(user, payload, startRequestId);
+    }
+
+    const quotaUnavailable =
+      error.message.includes("insufficient_spring_quota") ||
+      error.message.includes("spring_quota_expired");
+    if (!quotaUnavailable) {
+      console.error("[credits/consume] spring quota rpc failed", error);
+      return NextResponse.json({ error: "Failed to consume temporary quota" }, { status: 500 });
+    }
   }
 
   try {
-    const result = await consumeCreditAndCreateSession(user, payload);
+    const requestSource: StartRequestSource = "project_credit";
+    const result = await consumeCreditAndCreateSession(
+      user,
+      payload,
+      startRequestId,
+      buildStartRequestFingerprint(requestSource, payload),
+    );
     return NextResponse.json({
       success: true,
       credits: result.credits,
       usedTemporaryQuota: false,
       campaign: buildCampaignPayload(campaignRow),
       sessionId: result.sessionId,
+      idempotentReplay: result.replayed,
     });
   } catch (error) {
+    if (error instanceof IdempotencyConflictError) {
+      return buildIdempotencyConflictResponse(user, payload, startRequestId);
+    }
     if (String(error).includes("Insufficient credits")) {
       return NextResponse.json(
         {

--- a/src/components/game/WelcomeScreen.tsx
+++ b/src/components/game/WelcomeScreen.tsx
@@ -273,6 +273,8 @@ export function WelcomeScreen({
     totalReferrals,
     loading: creditsLoading,
     consumeCredit,
+    completeGameStartRequest,
+    hasPendingGameStartRequest,
     redeemCode,
     signOut,
     isPasswordRecovery,
@@ -666,6 +668,15 @@ export function WelcomeScreen({
       openTokenPayConnection(true);
       return;
     }
+    const insufficientCredits =
+      result?.status === 400 &&
+      result.error?.toLowerCase().includes("insufficient") === true;
+    if (!insufficientCredits) {
+      toast.error(t("welcome.toast.startFail.title"), {
+        description: t("welcome.toast.startFail.description"),
+      });
+      return;
+    }
     if (REFERRAL_BONUS_ENABLED) {
       setIsShareOpen(true);
     } else {
@@ -714,6 +725,16 @@ export function WelcomeScreen({
     return `${navigator.language || "unknown"}|${timeZone}`;
   };
 
+  const buildCreditConsumeOptions = () => ({
+    createSession: true,
+    playerCount,
+    difficulty,
+    usedCustomKey: getModelSource() !== "project",
+    modelUsed: getGeneratorModel(),
+    userEmail: user?.email ?? null,
+    region: getClientRegion(),
+  });
+
   const waitForStartAnimation = async (startedAt: number) => {
     const remaining = Math.max(0, 800 - (Date.now() - startedAt));
     if (remaining <= 0) return;
@@ -736,28 +757,23 @@ export function WelcomeScreen({
     setIsTransitioning(true);
 
     let creditAuthorized = skipCredit;
+    let startRequestId: string | undefined;
     try {
       let gameSessionId: string | null = null;
       if (!skipCredit) {
-        const result = await consumeCredit({
-          createSession: true,
-          playerCount,
-          difficulty,
-          usedCustomKey: getModelSource() !== "project",
-          modelUsed: getGeneratorModel(),
-          userEmail: user?.email ?? null,
-          region: getClientRegion(),
-        });
+        const result = await consumeCredit(buildCreditConsumeOptions());
         if (!result.success) {
           handleCreditFailure(result);
           return;
         }
         creditAuthorized = true;
+        startRequestId = result.startRequestId;
         gameSessionId = result.sessionId ?? null;
       }
 
       await waitForStartAnimation(animationStartedAt);
       await onStart(buildStartOptions(gameSessionId));
+      completeGameStartRequest(startRequestId);
     } catch (error) {
       console.error("[welcome] failed to start game", error);
       if (!creditAuthorized) {
@@ -806,6 +822,7 @@ export function WelcomeScreen({
     if (
       !demoModeActive &&
       !hasExternalSource &&
+      !hasPendingGameStartRequest(buildCreditConsumeOptions()) &&
       credits !== null &&
       credits <= LOW_CREDIT_THRESHOLD &&
       !hasSpringQuota &&

--- a/src/hooks/useCredits.ts
+++ b/src/hooks/useCredits.ts
@@ -25,6 +25,14 @@ import {
 import { readReferralFromStorage, removeReferralFromStorage } from "@/lib/referral";
 import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
 import { fetchWithTimeout } from "@/lib/request-timeout";
+import {
+  buildGameStartIntentFingerprint,
+  completeGameStartRequest as clearPendingGameStartRequest,
+  getOrCreateGameStartRequest,
+  hasPendingGameStartRequest as readPendingGameStartRequest,
+  runGameStartRequestWithRetry,
+  shouldRetryGameStartRequest,
+} from "@/lib/game-start-idempotency";
 
 const REFERRAL_ENDPOINT = "/api/credits/referral";
 const REDEEM_ENDPOINT = "/api/credits/redeem";
@@ -53,11 +61,27 @@ export type ConsumeCreditResult = {
   success: boolean;
   credits?: number;
   sessionId?: string | null;
+  startRequestId?: string;
+  idempotentReplay?: boolean;
   error?: string;
   code?: string;
   recoveryAction?: string;
   status?: number;
 };
+
+function buildStartIntentFingerprint(
+  options: ConsumeCreditOptions,
+  modelSource: ReturnType<typeof getModelSource>,
+): string {
+  return buildGameStartIntentFingerprint({
+    createSession: options.createSession === true,
+    difficulty: options.difficulty ?? null,
+    modelSource,
+    modelUsed: options.modelUsed ?? null,
+    playerCount: options.playerCount ?? null,
+    usedCustomKey: modelSource !== "project",
+  });
+}
 
 export function useCredits() {
   const [user, setUser] = useState<User | null>(null);
@@ -115,8 +139,14 @@ export function useCredits() {
     if (isDemoMode) return { success: true };
     if (!session) return { success: false, error: "unauthorized", status: 401 };
 
+    const modelSource = getModelSource();
+    const startIntentFingerprint = buildStartIntentFingerprint(options, modelSource);
+    const startRequestId = getOrCreateGameStartRequest(
+      session.user.id,
+      startIntentFingerprint,
+    );
+
     try {
-      const modelSource = getModelSource();
       const customEnabled = modelSource === "custom";
       const headerApiKey = customEnabled ? getZenmuxApiKey() : "";
       const dashscopeApiKey = customEnabled ? getDashscopeApiKey() : "";
@@ -124,11 +154,12 @@ export function useCredits() {
       const hasCustomKey = Boolean(headerApiKey || dashscopeApiKey || tokendanceApiKey);
       const tokenPayRequested = modelSource === "tokenpay";
       const tokendanceBaseUrl = customEnabled ? getTokendanceBaseUrl() : "";
-      const res = await fetchWithTimeout("/api/credits/consume", {
+      const requestInit: RequestInit = {
         method: "POST",
         headers: {
           Authorization: `Bearer ${session.access_token}`,
           "Content-Type": JSON_CONTENT_TYPE,
+          "Idempotency-Key": startRequestId,
           ...(headerApiKey ? { "X-Zenmux-Api-Key": headerApiKey } : {}),
           ...(dashscopeApiKey ? { "X-Dashscope-Api-Key": dashscopeApiKey } : {}),
           ...(tokendanceApiKey ? { "X-Tokendance-Api-Key": tokendanceApiKey } : {}),
@@ -141,7 +172,13 @@ export function useCredits() {
           ...options,
           usedCustomKey: tokenPayRequested || hasCustomKey,
         }),
-      }, CONSUME_CREDIT_TIMEOUT_MS);
+      };
+
+      const res = await runGameStartRequestWithRetry(
+        () =>
+          fetchWithTimeout("/api/credits/consume", requestInit, CONSUME_CREDIT_TIMEOUT_MS),
+        2,
+      );
 
       if (!res.ok) {
         let payload: {
@@ -158,8 +195,12 @@ export function useCredits() {
         } catch {
           // no-op
         }
+        if (!shouldRetryGameStartRequest(res.status)) {
+          clearPendingGameStartRequest(session.user.id, startRequestId);
+        }
         return {
           success: false,
+          startRequestId,
           status: res.status,
           error: typeof payload.error === "string" ? payload.error : `request_failed_${res.status}`,
           code: typeof payload.code === "string" ? payload.code : undefined,
@@ -172,19 +213,48 @@ export function useCredits() {
         credits: number;
         campaign?: SpringCampaignSnapshot;
         sessionId?: string | null;
+        idempotentReplay?: boolean;
       };
+      if (options.createSession && !payload.sessionId) {
+        return {
+          success: false,
+          startRequestId,
+          error: "missing_game_session",
+          status: 502,
+        };
+      }
       setCredits(payload.credits);
       if (payload.campaign) {
         setSpringCampaign(payload.campaign);
       }
-      return { success: true, credits: payload.credits, sessionId: payload.sessionId ?? null };
+      return {
+        success: true,
+        credits: payload.credits,
+        sessionId: payload.sessionId ?? null,
+        startRequestId,
+        idempotentReplay: payload.idempotentReplay === true,
+      };
     } catch (error) {
       return {
         success: false,
+        startRequestId,
         error: error instanceof Error ? error.message : "network_error",
       };
     }
   }, [isDemoMode, session]);
+
+  const completeGameStartRequest = useCallback((requestId: string | undefined) => {
+    if (!requestId || !session?.user.id) return;
+    clearPendingGameStartRequest(session.user.id, requestId);
+  }, [session]);
+
+  const hasPendingGameStartRequest = useCallback((options: ConsumeCreditOptions) => {
+    if (!session?.user.id) return false;
+    return readPendingGameStartRequest(
+      session.user.id,
+      buildStartIntentFingerprint(options, getModelSource()),
+    );
+  }, [session]);
 
   const redeemCode = useCallback(async (code: string): Promise<{
     success: boolean;
@@ -478,6 +548,8 @@ export function useCredits() {
     loading: loading || demoConfigLoading,
     fetchCredits,
     consumeCredit,
+    completeGameStartRequest,
+    hasPendingGameStartRequest,
     redeemCode,
     signOut,
     isPasswordRecovery,

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -149,6 +149,10 @@
         "title": "Failed to deduct credits",
         "description": "Please try again or recharge your credits."
       },
+      "startFail": {
+        "title": "Game start did not complete",
+        "description": "Retrying will reuse this request and will not deduct credits again."
+      },
       "keyExhausted": {
         "title": "API Key balance exhausted",
         "description": "Please top up at the respective platform (zenmux.ai or Alibaba Cloud Dashscope) before starting the game."

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -149,6 +149,10 @@
         "title": "扣除额度失败",
         "description": "请稍后重试或前往充值额度。"
       },
+      "startFail": {
+        "title": "开局请求未完成",
+        "description": "系统会复用本次请求，重新开始不会重复扣除额度。"
+      },
       "keyExhausted": {
         "title": "API Key 余额已耗尽",
         "description": "请前往对应平台（zenmux.ai 或阿里云百炼）充值后再开始游戏。"

--- a/src/lib/game-start-idempotency.test.ts
+++ b/src/lib/game-start-idempotency.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildGameStartIntentFingerprint,
+  completeGameStartRequest,
+  GAME_START_REQUEST_TTL_MS,
+  getOrCreateGameStartRequest,
+  hasPendingGameStartRequest,
+  runGameStartRequestWithRetry,
+} from "@/lib/game-start-idempotency";
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string) {
+    this.values.delete(key);
+  }
+}
+
+class WriteFailingStorage extends MemoryStorage {
+  override setItem() {
+    throw new Error("quota_exceeded");
+  }
+
+  override removeItem() {
+    throw new Error("quota_exceeded");
+  }
+}
+
+test("相同用户和开局意图会复用同一个请求 ID", () => {
+  const storage = new MemoryStorage();
+  const fingerprint = buildGameStartIntentFingerprint({ playerCount: 10, source: "project" });
+  const first = getOrCreateGameStartRequest("user-1", fingerprint, { now: 1_000, storage });
+  const second = getOrCreateGameStartRequest("user-1", fingerprint, { now: 2_000, storage });
+
+  assert.equal(second, first);
+});
+
+test("完成开局后，下次相同配置会生成新的请求 ID", () => {
+  const storage = new MemoryStorage();
+  const fingerprint = buildGameStartIntentFingerprint({ playerCount: 10, source: "project" });
+  const first = getOrCreateGameStartRequest("user-2", fingerprint, { now: 1_000, storage });
+  assert.equal(hasPendingGameStartRequest("user-2", fingerprint, { now: 1_500, storage }), true);
+  completeGameStartRequest("user-2", first, { now: 2_000, storage });
+  assert.equal(hasPendingGameStartRequest("user-2", fingerprint, { now: 2_500, storage }), false);
+  const next = getOrCreateGameStartRequest("user-2", fingerprint, { now: 3_000, storage });
+
+  assert.notEqual(next, first);
+});
+
+test("超时窗口结束后不会复用陈旧请求 ID", () => {
+  const storage = new MemoryStorage();
+  const fingerprint = buildGameStartIntentFingerprint({ playerCount: 10, source: "project" });
+  const first = getOrCreateGameStartRequest("user-3", fingerprint, { now: 1_000, storage });
+  const next = getOrCreateGameStartRequest("user-3", fingerprint, {
+    now: 1_000 + GAME_START_REQUEST_TTL_MS + 1,
+    storage,
+  });
+
+  assert.notEqual(next, first);
+});
+
+test("不同开局配置和不同用户不会共享请求 ID", () => {
+  const storage = new MemoryStorage();
+  const project = buildGameStartIntentFingerprint({ playerCount: 10, source: "project" });
+  const tokenPay = buildGameStartIntentFingerprint({ playerCount: 10, source: "tokenpay" });
+
+  const projectId = getOrCreateGameStartRequest("user-4", project, { now: 1_000, storage });
+  const tokenPayId = getOrCreateGameStartRequest("user-4", tokenPay, { now: 1_000, storage });
+  const otherUserId = getOrCreateGameStartRequest("user-5", project, { now: 1_000, storage });
+
+  assert.notEqual(tokenPayId, projectId);
+  assert.notEqual(otherUserId, projectId);
+});
+
+test("24 小时内不会因未完成意图超过八个而丢失最早请求 ID", () => {
+  const storage = new MemoryStorage();
+  const firstFingerprint = buildGameStartIntentFingerprint({ playerCount: 6, sequence: 0 });
+  const firstId = getOrCreateGameStartRequest("user-many", firstFingerprint, {
+    now: 1_000,
+    storage,
+  });
+
+  for (let sequence = 1; sequence < 10; sequence += 1) {
+    getOrCreateGameStartRequest(
+      "user-many",
+      buildGameStartIntentFingerprint({ playerCount: 6 + sequence, sequence }),
+      { now: 1_000 + sequence, storage },
+    );
+  }
+
+  assert.equal(
+    getOrCreateGameStartRequest("user-many", firstFingerprint, { now: 2_000, storage }),
+    firstId,
+  );
+});
+
+test("localStorage 写失败后，同页重试仍以内存中的请求 ID 为准", () => {
+  const storage = new WriteFailingStorage();
+  const fingerprint = buildGameStartIntentFingerprint({ playerCount: 10, source: "project" });
+  const first = getOrCreateGameStartRequest("user-write-fail", fingerprint, {
+    now: 1_000,
+    storage,
+  });
+  const second = getOrCreateGameStartRequest("user-write-fail", fingerprint, {
+    now: 2_000,
+    storage,
+  });
+
+  assert.equal(second, first);
+});
+
+test("意图指纹不受对象字段顺序影响", () => {
+  assert.equal(
+    buildGameStartIntentFingerprint({ source: "project", config: { difficulty: "normal", players: 10 } }),
+    buildGameStartIntentFingerprint({ config: { players: 10, difficulty: "normal" }, source: "project" }),
+  );
+});
+
+test("网络异常后会使用同一个逻辑请求自动重试一次", async () => {
+  let attempts = 0;
+  const delays: number[] = [];
+  const response = await runGameStartRequestWithRetry(async () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("connection_lost");
+    return new Response(JSON.stringify({ success: true }), { status: 200 });
+  }, 2, {
+    random: () => 0,
+    sleep: async (delayMs) => { delays.push(delayMs); },
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(attempts, 2);
+  assert.deepEqual(delays, [250]);
+});
+
+test("服务端瞬时错误会重试，确定的客户端错误不会重试", async () => {
+  let transientAttempts = 0;
+  const recovered = await runGameStartRequestWithRetry(async () => {
+    transientAttempts += 1;
+    return new Response(null, { status: transientAttempts === 1 ? 503 : 200 });
+  }, 2, { random: () => 0, sleep: async () => undefined });
+  assert.equal(recovered.status, 200);
+  assert.equal(transientAttempts, 2);
+
+  let invalidAttempts = 0;
+  const invalid = await runGameStartRequestWithRetry(async () => {
+    invalidAttempts += 1;
+    return new Response(null, { status: 400 });
+  });
+  assert.equal(invalid.status, 400);
+  assert.equal(invalidAttempts, 1);
+});
+
+test("429 重试遵守有上限的 Retry-After", async () => {
+  let attempts = 0;
+  const delays: number[] = [];
+  const response = await runGameStartRequestWithRetry(async () => {
+    attempts += 1;
+    if (attempts === 1) {
+      return new Response(null, { status: 429, headers: { "Retry-After": "30" } });
+    }
+    return new Response(null, { status: 200 });
+  }, 2, {
+    sleep: async (delayMs) => { delays.push(delayMs); },
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(delays, [5_000]);
+});

--- a/src/lib/game-start-idempotency.ts
+++ b/src/lib/game-start-idempotency.ts
@@ -1,0 +1,236 @@
+import { generateUUID } from "@/lib/utils";
+import { GAME_SESSION_RESUME_WINDOW_MS } from "@/lib/game-session-policy";
+
+const STORAGE_KEY_PREFIX = "wolfcha_pending_game_starts_v1";
+// 与已授权游戏会话的恢复窗口保持一致；响应丢失或角色生成失败后，
+// 同一开局意图在 24 小时内始终复用原扣费会话。
+const REQUEST_TTL_MS = GAME_SESSION_RESUME_WINDOW_MS;
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+type PendingGameStartRequest = {
+  requestId: string;
+  fingerprint: string;
+  createdAt: number;
+};
+
+const memoryPendingByUser = new Map<string, PendingGameStartRequest[]>();
+// 一旦浏览器拒绝写入 localStorage，本页后续必须以内存为准，否则旧存储会
+// 在下一次读取时覆盖刚生成的幂等键。
+const memoryOnlyUsers = new Set<string>();
+
+function getStorage(): StorageLike | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getStorageKey(userId: string): string {
+  return `${STORAGE_KEY_PREFIX}:${userId}`;
+}
+
+function isPendingRequest(value: unknown): value is PendingGameStartRequest {
+  if (!value || typeof value !== "object") return false;
+  const request = value as Partial<PendingGameStartRequest>;
+  return (
+    typeof request.requestId === "string" &&
+    typeof request.fingerprint === "string" &&
+    typeof request.createdAt === "number"
+  );
+}
+
+function readPendingRequests(
+  userId: string,
+  now: number,
+  storage: StorageLike | null,
+): PendingGameStartRequest[] {
+  const memoryRequests = memoryPendingByUser.get(userId) ?? [];
+  let storageRequests: PendingGameStartRequest[] = [];
+  if (storage && !memoryOnlyUsers.has(userId)) {
+    try {
+      const raw = storage.getItem(getStorageKey(userId));
+      const parsed: unknown = raw ? JSON.parse(raw) : [];
+      if (Array.isArray(parsed)) {
+        storageRequests = parsed.filter(isPendingRequest);
+      }
+    } catch {
+      // Keep the in-memory copy when browser storage is unavailable or corrupted.
+    }
+  }
+
+  const latestByFingerprint = new Map<string, PendingGameStartRequest>();
+  for (const request of [...storageRequests, ...memoryRequests]) {
+    if (now - request.createdAt > REQUEST_TTL_MS) continue;
+    const previous = latestByFingerprint.get(request.fingerprint);
+    if (!previous || request.createdAt >= previous.createdAt) {
+      latestByFingerprint.set(request.fingerprint, request);
+    }
+  }
+  const fresh = [...latestByFingerprint.values()].sort(
+    (left, right) => left.createdAt - right.createdAt,
+  );
+  memoryPendingByUser.set(userId, fresh);
+  return fresh;
+}
+
+function writePendingRequests(
+  userId: string,
+  requests: PendingGameStartRequest[],
+  storage: StorageLike | null,
+) {
+  const normalized = requests;
+  memoryPendingByUser.set(userId, normalized);
+  if (!storage) return;
+
+  try {
+    if (normalized.length === 0) {
+      storage.removeItem(getStorageKey(userId));
+    } else {
+      storage.setItem(getStorageKey(userId), JSON.stringify(normalized));
+    }
+    memoryOnlyUsers.delete(userId);
+  } catch {
+    // The in-memory copy still protects retries in the active page.
+    memoryOnlyUsers.add(userId);
+  }
+}
+
+function sortForStableJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortForStableJson);
+  if (!value || typeof value !== "object") return value;
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, nested]) => [key, sortForStableJson(nested)]),
+  );
+}
+
+export function buildGameStartIntentFingerprint(input: Record<string, unknown>): string {
+  return JSON.stringify(sortForStableJson(input));
+}
+
+export function getOrCreateGameStartRequest(
+  userId: string,
+  fingerprint: string,
+  options: { now?: number; storage?: StorageLike | null } = {},
+): string {
+  const now = options.now ?? Date.now();
+  const storage = options.storage === undefined ? getStorage() : options.storage;
+  const requests = readPendingRequests(userId, now, storage);
+  const existing = requests.find((request) => request.fingerprint === fingerprint);
+  if (existing) return existing.requestId;
+
+  const next: PendingGameStartRequest = {
+    requestId: generateUUID(),
+    fingerprint,
+    createdAt: now,
+  };
+  writePendingRequests(userId, [...requests, next], storage);
+  return next.requestId;
+}
+
+export function hasPendingGameStartRequest(
+  userId: string,
+  fingerprint: string,
+  options: { now?: number; storage?: StorageLike | null } = {},
+): boolean {
+  const now = options.now ?? Date.now();
+  const storage = options.storage === undefined ? getStorage() : options.storage;
+  return readPendingRequests(userId, now, storage).some(
+    (request) => request.fingerprint === fingerprint,
+  );
+}
+
+export function completeGameStartRequest(
+  userId: string,
+  requestId: string,
+  options: { now?: number; storage?: StorageLike | null } = {},
+) {
+  const now = options.now ?? Date.now();
+  const storage = options.storage === undefined ? getStorage() : options.storage;
+  const requests = readPendingRequests(userId, now, storage);
+  writePendingRequests(
+    userId,
+    requests.filter((request) => request.requestId !== requestId),
+    storage,
+  );
+}
+
+export function shouldRetryGameStartRequest(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+type RetryOptions = {
+  sleep?: (delayMs: number) => Promise<void>;
+  random?: () => number;
+  now?: () => number;
+};
+
+const MAX_RETRY_DELAY_MS = 5_000;
+
+function getRetryDelayMs(
+  response: Response | null,
+  attempt: number,
+  random: () => number,
+  now: () => number,
+): number {
+  if (response?.status === 429) {
+    const retryAfter = response.headers.get("retry-after")?.trim();
+    if (retryAfter) {
+      const seconds = Number(retryAfter);
+      const parsedDelay = Number.isFinite(seconds)
+        ? seconds * 1_000
+        : Date.parse(retryAfter) - now();
+      if (Number.isFinite(parsedDelay) && parsedDelay >= 0) {
+        return Math.min(parsedDelay, MAX_RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  const baseDelay = 250 * 2 ** attempt;
+  const jitter = Math.floor(random() * 250);
+  return Math.min(baseDelay + jitter, MAX_RETRY_DELAY_MS);
+}
+
+export async function runGameStartRequestWithRetry(
+  attemptRequest: () => Promise<Response>,
+  maxAttempts = 2,
+  options: RetryOptions = {},
+): Promise<Response> {
+  const attemptLimit = Math.max(1, maxAttempts);
+  const sleep = options.sleep ?? ((delayMs) => new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  }));
+  const random = options.random ?? Math.random;
+  const now = options.now ?? Date.now;
+
+  for (let attempt = 0; attempt < attemptLimit; attempt += 1) {
+    let retryResponse: Response | null = null;
+    try {
+      const response = await attemptRequest();
+      if (
+        response.ok ||
+        !shouldRetryGameStartRequest(response.status) ||
+        attempt + 1 >= attemptLimit
+      ) {
+        return response;
+      }
+      retryResponse = response;
+      await response.body?.cancel().catch(() => undefined);
+    } catch (error) {
+      if (attempt + 1 >= attemptLimit) {
+        throw error instanceof Error ? error : new Error("network_error");
+      }
+    }
+
+    await sleep(getRetryDelayMs(retryResponse, attempt, random, now));
+  }
+
+  throw new Error("network_error");
+}
+
+export const GAME_START_REQUEST_TTL_MS = REQUEST_TTL_MS;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,5 +18,10 @@ export function generateUUID(): string {
     const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0"));
     return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10, 16).join("")}`;
   }
-  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  // 极旧环境也必须返回服务端可校验的 UUID，而不是自定义时间戳格式。
+  const bytes = Array.from({ length: 16 }, () => Math.floor(Math.random() * 256));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.map((byte) => byte.toString(16).padStart(2, "0"));
+  return `${hex.slice(0, 4).join("")}-${hex.slice(4, 6).join("")}-${hex.slice(6, 8).join("")}-${hex.slice(8, 10).join("")}-${hex.slice(10, 16).join("")}`;
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -236,6 +236,9 @@ export interface Database {
           model_used: string | null;
           user_email: string | null;
           region: string | null;
+          start_request_id: string | null;
+          start_request_fingerprint: string | null;
+          start_request_source: "demo" | "external" | "spring_quota" | "project_credit" | null;
           last_activity_at: string;
           created_at: string;
           ended_at: string | null;
@@ -259,6 +262,9 @@ export interface Database {
           model_used?: string | null;
           user_email?: string | null;
           region?: string | null;
+          start_request_id?: string | null;
+          start_request_fingerprint?: string | null;
+          start_request_source?: "demo" | "external" | "spring_quota" | "project_credit" | null;
           last_activity_at?: string;
           created_at?: string;
           ended_at?: string | null;
@@ -282,6 +288,9 @@ export interface Database {
           model_used?: string | null;
           user_email?: string | null;
           region?: string | null;
+          start_request_id?: string | null;
+          start_request_fingerprint?: string | null;
+          start_request_source?: "demo" | "external" | "spring_quota" | "project_credit" | null;
           last_activity_at?: string;
           created_at?: string;
           ended_at?: string | null;

--- a/supabase/migrations/20260901132040_idempotent_game_start_requests.sql
+++ b/supabase/migrations/20260901132040_idempotent_game_start_requests.sql
@@ -1,0 +1,318 @@
+-- 开局请求的幂等键。新列均允许历史记录保持 NULL；只有新 v2 RPC 写入这些列。
+alter table public.game_sessions
+  add column if not exists start_request_id uuid;
+
+alter table public.game_sessions
+  add column if not exists start_request_fingerprint text;
+
+-- source 需要持久化，才能拒绝同一幂等键被另一种扣费来源重放。
+alter table public.game_sessions
+  add column if not exists start_request_source text;
+
+-- 历史行的 request_id 都是 NULL，使用部分唯一索引即可保证新请求唯一，
+-- 同时避免为历史空值创建无意义索引项。生产发布会先在线并发创建同名索引；
+-- 这里保留 IF NOT EXISTS，确保全新环境也能完整迁移。
+create unique index if not exists game_sessions_user_start_request_uidx
+  on public.game_sessions (user_id, start_request_id)
+  where start_request_id is not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+      from pg_constraint
+     where conrelid = 'public.game_sessions'::regclass
+       and conname = 'game_sessions_start_request_source_check'
+  ) then
+    alter table public.game_sessions
+      add constraint game_sessions_start_request_source_check
+      check (
+        start_request_source is null
+        or start_request_source in ('demo', 'external', 'spring_quota', 'project_credit')
+      ) not valid;
+  end if;
+
+  if not exists (
+    select 1
+      from pg_constraint
+     where conrelid = 'public.game_sessions'::regclass
+       and conname = 'game_sessions_start_request_fields_check'
+  ) then
+    alter table public.game_sessions
+      add constraint game_sessions_start_request_fields_check
+      check (
+        (start_request_id is null
+         and start_request_fingerprint is null
+         and start_request_source is null)
+        or
+        (start_request_id is not null
+         and start_request_fingerprint is not null
+         and start_request_source is not null
+         and start_request_fingerprint ~ '^[0-9a-f]{64}$')
+      ) not valid;
+  end if;
+end;
+$$;
+
+alter table public.game_sessions
+  validate constraint game_sessions_start_request_source_check;
+
+alter table public.game_sessions
+  validate constraint game_sessions_start_request_fields_check;
+
+-- 新 RPC 使用 security invoker：只有明确获授 execute 的 service_role 可以调用，
+-- 由 service_role 自身的表权限完成事务内读写。旧 RPC 保留给迁移期间的旧应用。
+create or replace function public.consume_credit_for_authorized_game_session_v2(
+  p_user_id uuid,
+  p_player_count integer,
+  p_difficulty text default null,
+  p_model_used text default null,
+  p_user_email text default null,
+  p_region text default null,
+  p_start_request_id uuid default null,
+  p_start_request_fingerprint text default null
+)
+returns table(session_id uuid, credits integer, replayed boolean)
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+declare
+  v_credits integer;
+  v_session_id uuid;
+  v_existing_fingerprint text;
+  v_existing_source text;
+begin
+  if p_player_count is null or p_player_count <= 0 then
+    raise exception 'invalid_player_count' using errcode = '22023';
+  end if;
+
+  if p_start_request_id is null
+     or p_start_request_fingerprint is null
+     or p_start_request_fingerprint !~ '^[0-9a-f]{64}$' then
+    raise exception 'invalid_idempotency_request' using errcode = '22023';
+  end if;
+
+  -- 先锁额度行，保证同一用户的并发扣费请求串行化。
+  select uc.credits
+    into v_credits
+    from public.user_credits uc
+   where uc.id = p_user_id
+   for update;
+
+  if not found then
+    raise exception 'credits_not_found' using errcode = 'P0002';
+  end if;
+
+  -- 必须先查重放，再检查余额；重放不得因当前余额变化而再次扣费或失败。
+  select gs.id, gs.start_request_fingerprint, gs.start_request_source
+    into v_session_id, v_existing_fingerprint, v_existing_source
+    from public.game_sessions gs
+   where gs.user_id = p_user_id::text
+     and gs.start_request_id = p_start_request_id
+   for update;
+
+  if found then
+    if v_existing_fingerprint is distinct from p_start_request_fingerprint
+       or v_existing_source is distinct from 'project_credit' then
+      raise exception 'idempotency_conflict' using errcode = 'P0001';
+    end if;
+
+    return query select v_session_id, v_credits, true;
+    return;
+  end if;
+
+  if v_credits <= 0 then
+    raise exception 'insufficient_credits' using errcode = 'P0001';
+  end if;
+
+  update public.user_credits
+     set credits = v_credits - 1,
+         updated_at = now()
+   where id = p_user_id
+   returning user_credits.credits into v_credits;
+
+  insert into public.game_sessions (
+    user_id,
+    player_count,
+    difficulty,
+    completed,
+    used_custom_key,
+    credit_authorized,
+    model_used,
+    user_email,
+    region,
+    start_request_id,
+    start_request_fingerprint,
+    start_request_source,
+    last_activity_at
+  ) values (
+    p_user_id::text,
+    p_player_count,
+    p_difficulty,
+    false,
+    false,
+    true,
+    p_model_used,
+    p_user_email,
+    p_region,
+    p_start_request_id,
+    p_start_request_fingerprint,
+    'project_credit',
+    now()
+  )
+  returning id into v_session_id;
+
+  return query select v_session_id, v_credits, false;
+end;
+$$;
+
+-- 春季额度必须和 session 写入处于同一个函数事务；函数失败时两者一并回滚。
+create or replace function public.consume_spring_quota_for_authorized_game_session_v2(
+  p_user_id uuid,
+  p_campaign_code text,
+  p_quota_date date,
+  p_player_count integer,
+  p_difficulty text default null,
+  p_model_used text default null,
+  p_user_email text default null,
+  p_region text default null,
+  p_start_request_id uuid default null,
+  p_start_request_fingerprint text default null
+)
+returns table(
+  session_id uuid,
+  granted_quota integer,
+  consumed_quota integer,
+  expires_at timestamptz,
+  replayed boolean
+)
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+declare
+  v_session_id uuid;
+  v_existing_fingerprint text;
+  v_existing_source text;
+  v_granted_quota integer;
+  v_consumed_quota integer;
+  v_expires_at timestamptz;
+begin
+  if p_player_count is null or p_player_count <= 0 then
+    raise exception 'invalid_player_count' using errcode = '22023';
+  end if;
+
+  if p_campaign_code is null
+     or btrim(p_campaign_code) = ''
+     or p_quota_date is null
+     or p_start_request_id is null
+     or p_start_request_fingerprint is null
+     or p_start_request_fingerprint !~ '^[0-9a-f]{64}$' then
+    raise exception 'invalid_idempotency_request' using errcode = '22023';
+  end if;
+
+  -- 先锁 quota 行；同一 quota 的并发请求会在这里串行化。
+  select q.granted_quota, q.consumed_quota, q.expires_at
+    into v_granted_quota, v_consumed_quota, v_expires_at
+    from public.campaign_daily_quota q
+   where q.user_id = p_user_id
+     and q.campaign_code = p_campaign_code
+     and q.quota_date = p_quota_date
+   for update;
+
+  if not found then
+    raise exception 'spring_quota_not_found' using errcode = 'P0002';
+  end if;
+
+  -- 重放返回原 session 和当前 quota 状态；不可因 quota 已过期/耗尽而重复扣除。
+  select gs.id, gs.start_request_fingerprint, gs.start_request_source
+    into v_session_id, v_existing_fingerprint, v_existing_source
+    from public.game_sessions gs
+   where gs.user_id = p_user_id::text
+     and gs.start_request_id = p_start_request_id
+   for update;
+
+  if found then
+    if v_existing_fingerprint is distinct from p_start_request_fingerprint
+       or v_existing_source is distinct from 'spring_quota' then
+      raise exception 'idempotency_conflict' using errcode = 'P0001';
+    end if;
+
+    return query
+      select v_session_id,
+             v_granted_quota,
+             v_consumed_quota,
+             v_expires_at,
+             true;
+    return;
+  end if;
+
+  if v_expires_at <= now() then
+    raise exception 'spring_quota_expired' using errcode = 'P0001';
+  end if;
+
+  if v_consumed_quota >= v_granted_quota then
+    raise exception 'insufficient_spring_quota' using errcode = 'P0001';
+  end if;
+
+  update public.campaign_daily_quota
+     set consumed_quota = v_consumed_quota + 1,
+         updated_at = now()
+   where user_id = p_user_id
+     and campaign_code = p_campaign_code
+     and quota_date = p_quota_date;
+
+  insert into public.game_sessions (
+    user_id,
+    player_count,
+    difficulty,
+    completed,
+    used_custom_key,
+    credit_authorized,
+    model_used,
+    user_email,
+    region,
+    start_request_id,
+    start_request_fingerprint,
+    start_request_source,
+    last_activity_at
+  ) values (
+    p_user_id::text,
+    p_player_count,
+    p_difficulty,
+    false,
+    false,
+    true,
+    p_model_used,
+    p_user_email,
+    p_region,
+    p_start_request_id,
+    p_start_request_fingerprint,
+    'spring_quota',
+    now()
+  )
+  returning id into v_session_id;
+
+  return query
+    select v_session_id,
+           v_granted_quota,
+           v_consumed_quota + 1,
+           v_expires_at,
+           false;
+end;
+$$;
+
+revoke all on function public.consume_credit_for_authorized_game_session_v2(
+  uuid, integer, text, text, text, text, uuid, text
+) from public, anon, authenticated;
+grant execute on function public.consume_credit_for_authorized_game_session_v2(
+  uuid, integer, text, text, text, text, uuid, text
+) to service_role;
+
+revoke all on function public.consume_spring_quota_for_authorized_game_session_v2(
+  uuid, text, date, integer, text, text, text, text, uuid, text
+) from public, anon, authenticated;
+grant execute on function public.consume_spring_quota_for_authorized_game_session_v2(
+  uuid, text, date, integer, text, text, text, text, uuid, text
+) to service_role;


### PR DESCRIPTION
## 问题
开局扣费已经在数据库成功，但客户端响应丢失或后续角色生成失败时，用户重试会生成新的扣费请求，造成重复扣除；网络错误还被统一展示成额度不足。

## 修复
- 为每次开局持久化幂等请求 ID，并在 24 小时恢复窗口内复用
- 项目额度与活动额度通过事务 RPC 原子扣除并创建会话
- demo、自带 Key、TokenPay 分支同样写入请求身份并处理并发冲突
- 网络/限流重试使用同一幂等键并带退避；真实开局成功后才清理请求
- 区分额度不足与网络/服务端故障提示

## 验证
- 新增幂等/路由/迁移测试 19/19
- TokenPay 回归 45/45
- 单人上下文与随机座位回归 27/27
- TypeScript、目标 ESLint、Next.js 生产构建通过
- 生产数据库使用 service_role 做项目额度与活动额度真实事务回放，均只产生一个 session 且已 rollback
- Supabase 安全扫描无本次新增对象告警