### PR TITLE
feat: 支持自定义 OpenAI 兼容 LLM Provider 与多厂商 TTS（BYO Key 直接玩）

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,6 @@ Copy `.env.example` to `.env.local` and fill in:
 - `DASHSCOPE_API_KEY` — Alibaba Cloud model support
 - `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` / `STRIPE_PRICE_ID` — payments
 - `NEXT_PUBLIC_WATCHA_CLIENT_ID` / `WATCHA_CLIENT_SECRET` — optional OAuth
-- `NEWAPI_API_KEY` / `NEWAPI_BASE_URL` — optional custom model endpoint
 
 ## Architecture Overview
 
@@ -54,7 +53,7 @@ Defined in `src/types/game.ts`. Night: `NIGHT_START → NIGHT_GUARD_ACTION → N
 
 ### AI Integration
 
-- All LLM calls go through the **`/api/chat`** route (`src/app/api/chat/route.ts`), which proxies to ZenMux, Dashscope, or a custom NewAPI endpoint based on the model's provider
+- All LLM calls go through the **`/api/chat`** route (`src/app/api/chat/route.ts`), which proxies to ZenMux, Dashscope, TokenDance, or a user-defined OpenAI-compatible endpoint (provider `custom`, credentials via `X-Custom-Base-Url` / `X-Custom-Api-Key` headers) based on the model's provider
 - Models are registered in `src/types/game.ts` as `ALL_MODELS` and `PROJECT_MODELS` (each as `ModelRef` with `provider`, `model`, optional `temperature`/`reasoning`)
 - Prompt construction per phase is handled by `GamePhase` subclasses via `getPrompt(context, player): PromptResult`
 - `src/lib/llm.ts` — low-level streaming fetch helper
@@ -66,7 +65,7 @@ Defined in `src/types/game.ts`. Night: `NIGHT_START → NIGHT_GUARD_ACTION → N
 - `src/lib/audio-manager.ts` — `AudioManager` singleton; task-based sequential audio queue
 - `src/lib/narrator-audio-player.ts` — narrator TTS playback
 - `src/lib/narrator-voice.ts` — voice selection logic
-- `/api/tts` route — calls MiniMax TTS API for character speech synthesis
+- `/api/tts` route — dispatches to a TTS provider adapter registry (`src/lib/tts/`): MiniMax (built-in), OpenAI-compatible `/audio/speech`, Volcengine, ElevenLabs; client config lives in `src/lib/tts-client.ts`
 
 ### i18n
 
@@ -76,8 +75,9 @@ Defined in `src/types/game.ts`. Night: `NIGHT_START → NIGHT_GUARD_ACTION → N
 
 | Route | Purpose |
 |-------|---------|
-| `/api/chat` | LLM proxy (ZenMux / Dashscope / NewAPI) |
-| `/api/tts` | MiniMax TTS synthesis |
+| `/api/chat` | LLM proxy (ZenMux / Dashscope / TokenDance / custom OpenAI-compatible) |
+| `/api/llm-models` | Connectivity probe + model list proxy for custom LLM providers |
+| `/api/tts` | TTS synthesis (MiniMax / OpenAI-compatible / Volcengine / ElevenLabs) |
 | `/api/stt` | Speech-to-text |
 | `/api/credits/*` | Credit consumption, daily bonus, referral, redeem |
 | `/api/game-sessions` | Session tracking (Supabase) |
@@ -88,5 +88,5 @@ Defined in `src/types/game.ts`. Night: `NIGHT_START → NIGHT_GUARD_ACTION → N
 
 - **`FlowToken` pattern**: Before any async operation, capture `flowController.getToken()`. After `await`, call `token.isValid()` to abort if the flow was interrupted (e.g., game reset mid-speech).
 - **Phase prompt generation**: Add a new phase by creating/extending a `GamePhase` subclass in `src/game/phases/`, then register it in `PhaseManager`.
-- **Model routing**: Built-in models use ZenMux or Dashscope providers. Custom user API keys route through the NewAPI provider path. See `src/lib/api-keys.ts` for key resolution.
+- **Model routing**: Built-in models use ZenMux or Dashscope providers; TokenPay traffic routes through TokenDance. User-supplied keys cover ZenMux / Dashscope / TokenDance plus configurable OpenAI-compatible providers (`src/lib/custom-providers.ts`). See `src/lib/api-keys.ts` for key resolution.
 - Uses **pnpm** as package manager.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "test:single-player-context": "tsx --test src/lib/ai-logger.test.ts src/lib/character-generator-tokenpay.test.ts src/lib/character-generator-structured-output.test.ts src/lib/tokenpay-client.test.ts src/lib/game-master.badge-signup.test.ts src/lib/game-master.player-setup.test.ts src/lib/game-master.stream-logging.test.ts src/lib/speech-order.test.ts scripts/single-player-context-audit.test.ts src/lib/prompt-utils.test.ts src/hooks/useDialogueManager.test.ts",
+    "test:custom-providers": "tsx --test src/lib/custom-providers.test.ts src/lib/tts-client.test.ts server/custom-provider-contracts.test.ts",
     "audit:single-player-context": "tsx scripts/single-player-context-audit.ts",
     "audit:single-player-context:live": "node --env-file=.env.local --import tsx scripts/live-single-player-context-audit.ts",
     "audit:character-generation:live": "node --env-file=.env.local --import tsx scripts/live-character-generation-audit.ts",

--- a/server/custom-provider-contracts.test.ts
+++ b/server/custom-provider-contracts.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { joinProviderUrl } from "../src/lib/custom-providers";
+
+// 源码契约：与既有 server/*-contract.test.ts 风格一致，防止转发通道被误改。
+
+const chatRouteSource = readFileSync("src/app/api/chat/route.ts", "utf8");
+const llmModelsRouteSource = readFileSync("src/app/api/llm-models/route.ts", "utf8");
+const ttsRouteSource = readFileSync("src/app/api/tts/route.ts", "utf8");
+const openaiAdapterSource = readFileSync("src/lib/tts/openai-compatible.ts", "utf8");
+const volcengineAdapterSource = readFileSync("src/lib/tts/volcengine.ts", "utf8");
+const elevenlabsAdapterSource = readFileSync("src/lib/tts/elevenlabs.ts", "utf8");
+const minimaxAdapterSource = readFileSync("src/lib/tts/minimax.ts", "utf8");
+const registrySource = readFileSync("src/lib/tts/registry.ts", "utf8");
+
+test("自定义 LLM Provider：chat 路由接受 custom provider 且强制自备凭据", () => {
+  // 流式与批量路径都显式接受 custom
+  assert.match(chatRouteSource, /provider === "custom"/g);
+  // custom 分支必须要求 Base URL + API Key，拒绝回退系统 Key
+  assert.match(chatRouteSource, /此模型需要您提供自定义 Provider 的 Base URL 和 API Key/);
+  // 请求头常量贯通
+  assert.match(chatRouteSource, /x-custom-base-url/);
+  assert.match(chatRouteSource, /x-custom-api-key/);
+  // custom 转发只拼 /chat/completions，不允许内置 ZenMux URL
+  assert.match(chatRouteSource, /joinProviderUrl\([^)]*, "chat\/completions"\)/);
+});
+
+test("自定义 LLM Provider：模型列表代理需要登录且先探测 /models", () => {
+  assert.match(llmModelsRouteSource, /authenticateRequest/);
+  assert.match(llmModelsRouteSource, /joinProviderUrl\(baseUrl, "models"\)/);
+  // /models 不可用时用 max_tokens=1 的最小请求兜底，避免多耗 token
+  assert.match(llmModelsRouteSource, /max_tokens: 1/);
+  // 401/403 直接判定 key 无效
+  assert.match(llmModelsRouteSource, /response\.status === 401 \|\| response\.status === 403/);
+});
+
+test("自定义 LLM Provider：批量路径与流式路径共用凭据校验", () => {
+  assert.match(chatRouteSource, /runCustomProviderItem/);
+  assert.match(chatRouteSource, /hasCustomKeys/);
+  // 自带头要计入"玩家已有自定义 Key"，避免被误判为需要项目授权
+  assert.match(chatRouteSource, /\(earlyCustomBaseUrl && earlyCustomApiKey\)/);
+});
+
+test("TTS 路由按 provider 分发并保留项目模式对局校验", () => {
+  assert.match(ttsRouteSource, /resolveTtsRequest/);
+  assert.match(ttsRouteSource, /getTtsAdapter/);
+  // 无自定义凭据时仍校验游戏会话授权（项目 MiniMax 模式）
+  assert.match(ttsRouteSource, /hasAuthorizedActiveGameSession/);
+  // 旧协议头兼容
+  assert.match(ttsRouteSource, /x-minimax-api-key/);
+  // 新协议头
+  assert.match(ttsRouteSource, /x-tts-provider/);
+  // 连通性测试入口
+  assert.match(ttsRouteSource, /probe: true|handleProbe/);
+});
+
+test("OpenAI 兼容 TTS 适配器使用标准 /audio/speech 形状", () => {
+  assert.match(openaiAdapterSource, /joinProviderUrl\(baseUrl, "audio\/speech"\)/);
+  assert.match(openaiAdapterSource, /response_format: "mp3"/);
+  // 音色被网关拒绝时回退默认音色重试一次
+  assert.match(openaiAdapterSource, /retrying with default/);
+});
+
+test("火山引擎适配器使用私有协议且凭据齐全", () => {
+  assert.match(volcengineAdapterSource, /openspeech\.bytedance\.com\/api\/v1\/tts/);
+  assert.match(volcengineAdapterSource, /Bearer;\$\{accessToken\}/);
+  assert.match(volcengineAdapterSource, /cluster: CLUSTER/);
+  assert.match(volcengineAdapterSource, /SUCCESS_CODE = 3000/);
+});
+
+test("ElevenLabs 适配器按 voiceId 路径合成", () => {
+  assert.match(elevenlabsAdapterSource, /v1\/text-to-speech\//);
+  assert.match(elevenlabsAdapterSource, /xi-api-key/);
+});
+
+test("MiniMax 适配器保留旧路由的健壮性逻辑", () => {
+  // 双域名兜底
+  assert.match(minimaxAdapterSource, /api\.minimax\.chat/);
+  assert.match(minimaxAdapterSource, /api\.minimaxi\.com/);
+  // 2054 音色无效自动回退
+  assert.match(minimaxAdapterSource, /2054/);
+  // t2a_v2 端点
+  assert.match(minimaxAdapterSource, /t2a_v2/);
+});
+
+test("TTS 注册表覆盖全部五个 Provider", () => {
+  for (const id of ["minimax", "openai-compatible", "stepfun", "volcengine", "elevenlabs"]) {
+    assert.match(registrySource, new RegExp(id.replace("-", "\\-")));
+  }
+  // 未知 provider 回退 minimax，保持旧行为
+  assert.match(registrySource, /\?\? minimaxAdapter/);
+});
+
+test("StepFun 适配器复用 OpenAI speech 形状并预置官方音色", () => {
+  const stepfunSource = readFileSync("src/lib/tts/stepfun.ts", "utf8");
+  assert.match(stepfunSource, /createOpenAiSpeechAdapter/);
+  assert.match(stepfunSource, /api\.stepfun\.com/);
+  assert.match(stepfunSource, /step-tts-mini/);
+  assert.match(stepfunSource, /cixingnansheng/);
+  // 官方音色预设（纯数据、客户端可用）按性别分组，供角色创建采样
+  const voicesSource = readFileSync("src/lib/tts/stepfun-voices.ts", "utf8");
+  assert.match(voicesSource, /gender: "male"/);
+  assert.match(voicesSource, /gender: "female"/);
+  // 音色表不得引入服务端适配器（否则 node:https 会进入客户端 bundle）
+  assert.doesNotMatch(voicesSource, /openai-compatible|audio-util|node:https/);
+});
+
+test("URL 拼接规则：/models 与 /chat/completions 走同一条规范化路径", () => {
+  assert.equal(
+    joinProviderUrl("https://api.example.com/v1/", "chat/completions"),
+    "https://api.example.com/v1/chat/completions",
+  );
+});

--- a/server/tokenpay-session-recovery.test.ts
+++ b/server/tokenpay-session-recovery.test.ts
@@ -7,6 +7,7 @@ const gameMachineSource = readFileSync("src/store/game-machine.ts", "utf8");
 const chatRouteSource = readFileSync("src/app/api/chat/route.ts", "utf8");
 const ttsRouteSource = readFileSync("src/app/api/tts/route.ts", "utf8");
 const audioManagerSource = readFileSync("src/lib/audio-manager.ts", "utf8");
+const ttsClientSource = readFileSync("src/lib/tts-client.ts", "utf8");
 const apiKeysSource = readFileSync("src/lib/api-keys.ts", "utf8");
 const welcomeSource = readFileSync("src/components/game/WelcomeScreen.tsx", "utf8");
 
@@ -29,7 +30,9 @@ test("对局授权失效与余额不足使用不同错误码", () => {
 
 test("TokenPay 无自有语音 Key 时不会调用项目 MiniMax", () => {
   assert.match(audioManagerSource, /resolveAiVoiceAvailability/);
-  assert.match(audioManagerSource, /modelSource !== "project" && hasMinimaxKey\(\)/);
+  // MiniMax 自带头与"项目模式不带头"的契约已收敛到 tts-client 统一构建
+  assert.match(audioManagerSource, /buildTtsRequestHeaders/);
+  assert.match(ttsClientSource, /getModelSource\(\) === "project" \|\| !hasMinimaxKey\(\)/);
   assert.doesNotMatch(audioManagerSource, /X-TokenPay-Mode/);
   assert.doesNotMatch(ttsRouteSource, /hasAuthorizedActiveTokenPaySession/);
 });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -4,7 +4,8 @@ import {
   GAME_SESSION_EXPIRED_CODE,
   GAME_SESSION_EXPIRED_MESSAGE,
 } from "@/lib/game-session-policy";
-import { ALL_MODELS, PROJECT_MODELS } from "@/types/game";
+import { ALL_MODELS, PROJECT_MODELS, type LlmProviderId } from "@/types/game";
+import { joinProviderUrl } from "@/lib/custom-providers";
 import { randomUUID } from "node:crypto";
 import {
   getConnectedTokenPayApiKey,
@@ -45,7 +46,7 @@ const REQUEST_ID_HEADER = "X-Request-ID";
 const ATTEMPT_ID_HEADER = "X-Attempt-ID";
 const ATTEMPT_HEADER = "X-Attempt";
 
-type Provider = "zenmux" | "dashscope" | "tokendance";
+type Provider = LlmProviderId;
 
 type AttemptContext = {
   userId: string;
@@ -421,12 +422,107 @@ type RequestMeta = {
   requestId?: unknown;
 };
 
+type CustomProviderItemInput = {
+  baseUrl: string | null;
+  apiKey: string | null;
+  model: string;
+  messages: unknown[];
+  temperature: number;
+  max_tokens?: number;
+  reasoning_effort?: ReasoningEffort;
+  response_format?: unknown;
+  context: AttemptContext;
+};
+
+// 自定义 OpenAI 兼容 Provider 的批量（非流式）转发。
+// 能力未知：只透传兼容面最广的参数（json_object、reasoning_effort）。
+async function runCustomProviderItem(
+  input: CustomProviderItemInput,
+): Promise<
+  | { ok: true; data: unknown }
+  | { ok: false; status: number; error: string; details?: unknown }
+> {
+  if (!input.baseUrl || !input.apiKey) {
+    return { ok: false, status: 401, error: "此模型需要您提供自定义 Provider 的 Base URL 和 API Key" };
+  }
+  const customUrl = joinProviderUrl(input.baseUrl, "chat/completions");
+  if (!customUrl) {
+    return { ok: false, status: 500, error: "Invalid custom provider Base URL" };
+  }
+
+  const requestBody: Record<string, unknown> = {
+    model: input.model,
+    messages: input.messages,
+    temperature: input.temperature,
+  };
+  if (typeof input.max_tokens === "number" && Number.isFinite(input.max_tokens)) {
+    // StepFun 的 flash 系列是混合推理模型：reasoning 也计入 max_tokens，前端按
+    // 非推理模型设定的 4200 会被思考耗尽导致 content 为空。对推理输出统一放大
+    // 并默认压低思考深度，保证正文拿得到预算。
+    const isStepFun = /stepfun\.com/i.test(input.baseUrl);
+    const base = Math.max(16, Math.floor(input.max_tokens));
+    requestBody.max_tokens = isStepFun ? Math.min(16384, base * 3) : base;
+    if (isStepFun && !input.reasoning_effort) {
+      requestBody.reasoning_effort = "low";
+    }
+  }
+  if (isReasoningEffort(input.reasoning_effort)) {
+    requestBody.reasoning_effort = input.reasoning_effort;
+  }
+  if (
+    input.response_format &&
+    typeof input.response_format === "object" &&
+    (input.response_format as { type?: unknown }).type === "json_object"
+  ) {
+    requestBody.response_format = input.response_format;
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetchProvider(customUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${input.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+    }, input.context);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    return {
+      ok: false,
+      status: response.status,
+      error: `自定义 Provider 请求失败（HTTP ${response.status}）`,
+      details: errorText.slice(0, 600),
+    };
+  }
+
+  try {
+    const result = await response.json();
+    await recordAttempt(input.context, "success", responseUsage(result));
+    return { ok: true, data: result };
+  } catch (error) {
+    await recordAttempt(input.context, "error", { errorCode: "invalid_response" });
+    throw error;
+  }
+}
+
 async function runBatchItem(
   payload: ChatRequestPayload,
   headerApiKey: string | null,
   headerDashscopeKey: string | null,
   headerTokendanceKey: string | null,
   headerTokendanceBaseUrl: string | null,
+  headerCustomBaseUrl: string | null,
+  headerCustomApiKey: string | null,
   meta: RequestMeta,
 ): Promise<
   | { ok: true; data: unknown }
@@ -456,7 +552,7 @@ async function runBatchItem(
   }
 
   const modelProvider: Provider | null =
-    provider === "dashscope" || provider === "zenmux" || provider === "tokendance" ? provider : getProviderForModel(model);
+    provider === "dashscope" || provider === "zenmux" || provider === "tokendance" || provider === "custom" ? provider : getProviderForModel(model);
   if (!modelProvider) {
     return { ok: false, status: 400, error: `Unknown model: ${String(model ?? "").trim() || "unknown"}` };
   }
@@ -685,6 +781,20 @@ async function runBatchItem(
     }
   }
 
+  if (modelProvider === "custom") {
+    return await runCustomProviderItem({
+      baseUrl: headerCustomBaseUrl,
+      apiKey: headerCustomApiKey,
+      model,
+      messages: processedMessages,
+      temperature: cappedTemperature,
+      max_tokens,
+      reasoning_effort,
+      response_format,
+      context,
+    });
+  }
+
   if (hasAnyCustomKeyHeader && !headerApiKey) {
     return { ok: false, status: 401, error: "已启用自定义 Key，但未提供 Zenmux API Key（已拒绝回退到系统 Key）" };
   }
@@ -788,10 +898,13 @@ export async function POST(request: NextRequest) {
   const earlyZenmuxKey = request.headers.get("x-zenmux-api-key")?.trim();
   const earlyDashscopeKey = request.headers.get("x-dashscope-api-key")?.trim();
   const earlyTokendanceKey = tokenPayApiKey || request.headers.get("x-tokendance-api-key")?.trim();
+  const earlyCustomBaseUrl = request.headers.get("x-custom-base-url")?.trim();
+  const earlyCustomApiKey = request.headers.get("x-custom-api-key")?.trim();
   const hasCustomKeys = Boolean(
     (earlyZenmuxKey ?? "") ||
     (earlyDashscopeKey ?? "") ||
-    (earlyTokendanceKey ?? "")
+    (earlyTokendanceKey ?? "") ||
+    (earlyCustomBaseUrl && earlyCustomApiKey)
   );
 
   if (!hasCustomKeys) {
@@ -834,6 +947,8 @@ export async function POST(request: NextRequest) {
           headerDashscopeKey,
           headerTokendanceKey,
           headerTokendanceBaseUrl,
+          request.headers.get("x-custom-base-url")?.trim() || null,
+          request.headers.get("x-custom-api-key")?.trim() || null,
           {
             userId: auth.user.id,
             sessionId,
@@ -872,7 +987,7 @@ export async function POST(request: NextRequest) {
       provider,
     } = body;
     const modelProvider: Provider | null =
-      provider === "dashscope" || provider === "zenmux" || provider === "tokendance" ? provider : getProviderForModel(model);
+      provider === "dashscope" || provider === "zenmux" || provider === "tokendance" || provider === "custom" ? provider : getProviderForModel(model);
     if (!modelProvider) {
       // Reject unknown models early to avoid mis-routing.
       return NextResponse.json(
@@ -1157,6 +1272,105 @@ export async function POST(request: NextRequest) {
           errorResponse.headers.set(TOKENPAY_RECOVERY_HEADER, recoveryAction);
         }
         return errorResponse;
+      }
+
+      if (stream) {
+        const headers = new Headers();
+        headers.set("Content-Type", "text/event-stream");
+        headers.set("Cache-Control", "no-cache");
+        headers.set("Connection", "keep-alive");
+
+        return trackedStreamResponse(new Response(response.body, { headers }), attemptContext);
+      }
+
+      try {
+        const result = await response.json();
+        await recordAttempt(attemptContext, "success", responseUsage(result));
+        return NextResponse.json(result);
+      } catch (error) {
+        await recordAttempt(attemptContext, "error", { errorCode: "invalid_response" });
+        throw error;
+      }
+    }
+
+    if (modelProvider === "custom") {
+      const headerCustomBaseUrl = request.headers.get("x-custom-base-url")?.trim() || null;
+      const headerCustomApiKey = request.headers.get("x-custom-api-key")?.trim() || null;
+      if (!headerCustomBaseUrl || !headerCustomApiKey) {
+        return NextResponse.json(
+          { error: "此模型需要您提供自定义 Provider 的 Base URL 和 API Key" },
+          { status: 401 }
+        );
+      }
+
+      const customUrl = joinProviderUrl(headerCustomBaseUrl, "chat/completions");
+      if (!customUrl) {
+        return NextResponse.json(
+          { error: "Invalid custom provider Base URL" },
+          { status: 500 }
+        );
+      }
+
+      const requestBody: Record<string, unknown> = {
+        model,
+        messages: processedMessages,
+        temperature: cappedTemperature,
+      };
+
+      const reasoningEffort = isReasoningEffort(reasoning_effort) ? reasoning_effort : undefined;
+
+      if (typeof max_tokens === "number" && Number.isFinite(max_tokens)) {
+        // 与批量分支同因：StepFun flash 系列为混合推理模型，reasoning 计入
+        // max_tokens；放大预算并默认压低思考深度，避免正文为空。
+        const isStepFun = /stepfun\.com/i.test(headerCustomBaseUrl ?? "");
+        const base = Math.max(16, Math.floor(max_tokens));
+        requestBody.max_tokens = isStepFun ? Math.min(16384, base * 3) : base;
+        if (isStepFun && !reasoningEffort) {
+          requestBody.reasoning_effort = "low";
+        }
+      }
+
+      if (stream) {
+        requestBody.stream = true;
+      }
+
+      if (reasoningEffort) {
+        requestBody.reasoning_effort = reasoningEffort;
+      }
+
+      // 自定义 Provider 的能力未知，response_format 只透传兼容面最广的 json_object
+      if (
+        response_format &&
+        typeof response_format === "object" &&
+        (response_format as { type?: unknown }).type === "json_object"
+      ) {
+        requestBody.response_format = response_format;
+      }
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+
+      let response: Response;
+      try {
+        response = await fetchProvider(customUrl, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${headerCustomApiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(requestBody),
+          signal: controller.signal,
+        }, attemptContext);
+      } finally {
+        clearTimeout(timeoutId);
+      }
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return NextResponse.json(
+          { error: `自定义 Provider 请求失败（HTTP ${response.status}）`, details: errorText.slice(0, 600) },
+          { status: response.status }
+        );
       }
 
       if (stream) {

--- a/src/app/api/credits/consume/route.ts
+++ b/src/app/api/credits/consume/route.ts
@@ -464,6 +464,9 @@ export async function POST(request: Request) {
   const headerZenmuxKey = request.headers.get("x-zenmux-api-key")?.trim();
   const headerDashscopeKey = request.headers.get("x-dashscope-api-key")?.trim();
   const headerTokendanceKey = request.headers.get("x-tokendance-api-key")?.trim();
+  // 自定义 OpenAI 兼容 Provider 的凭据同样构成"自带 Key"路径（免扣项目额度）
+  const headerCustomBaseUrl = request.headers.get("x-custom-base-url")?.trim();
+  const headerCustomApiKey = request.headers.get("x-custom-api-key")?.trim();
   const tokenPayRequested = request.headers.get(TOKENPAY_MODE_HEADER) === "true";
   let tokenPayConnected = false;
   if (tokenPayRequested) {
@@ -492,7 +495,11 @@ export async function POST(request: Request) {
     );
   }
   const hasExternalKey = Boolean(
-    headerZenmuxKey || headerDashscopeKey || headerTokendanceKey || tokenPayConnected,
+    headerZenmuxKey ||
+    headerDashscopeKey ||
+    headerTokendanceKey ||
+    tokenPayConnected ||
+    (headerCustomBaseUrl && headerCustomApiKey),
   );
   const now = new Date();
   const springCampaignBase = buildSpringCampaignBase(now);

--- a/src/app/api/llm-models/route.ts
+++ b/src/app/api/llm-models/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateRequest } from "@/lib/api-auth";
+import { joinProviderUrl, normalizeBaseUrl } from "@/lib/custom-providers";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const PROBE_TIMEOUT_MS = 15_000;
+const FALLBACK_PROBE_MODEL = "gpt-4o-mini";
+const MAX_MODELS = 500;
+
+interface ProbeSuccess {
+  ok: true;
+  models: string[];
+  fellBackToChatProbe: boolean;
+}
+
+interface ProbeFailure {
+  ok: false;
+  error: string;
+}
+
+/**
+ * 自定义 OpenAI 兼容 Provider 的连通性测试与模型列表代理。
+ *
+ * 浏览器直连各厂商 API 会被 CORS 拦截，统一走本路由：
+ * 优先 GET {base}/models（零 token 消耗）；网关未实现 /models 时
+ * 退回一条 max_tokens=1 的最小对话请求。
+ */
+export async function POST(req: NextRequest) {
+  const auth = await authenticateRequest(req as unknown as Request);
+  if ("error" in auth) return auth.error;
+
+  const baseUrl = normalizeBaseUrl(req.headers.get("x-custom-base-url")?.trim() ?? "");
+  const apiKey = req.headers.get("x-custom-api-key")?.trim() ?? "";
+  const probeModel = req.headers.get("x-custom-model")?.trim() ?? "";
+
+  if (!baseUrl || !apiKey) {
+    return NextResponse.json({ ok: false, error: "Missing X-Custom-Base-Url or X-Custom-Api-Key" }, { status: 400 });
+  }
+
+  const modelsUrl = joinProviderUrl(baseUrl, "models");
+  if (!modelsUrl) {
+    return NextResponse.json({ ok: false, error: "Invalid Base URL" }, { status: 400 });
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    const response = await fetch(modelsUrl, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: controller.signal,
+      cache: "no-store",
+    }).finally(() => clearTimeout(timeoutId));
+
+    if (response.ok) {
+      const data: unknown = await response.json().catch(() => null);
+      return NextResponse.json({
+        ok: true,
+        models: extractModelIds(data),
+        fellBackToChatProbe: false,
+      } satisfies ProbeSuccess);
+    }
+
+    // 401/403 说明 key 无效，直接判定失败；其余状态可能是网关没实现 /models
+    if (response.status === 401 || response.status === 403) {
+      return NextResponse.json({
+        ok: false,
+        error: `API Key 验证失败（HTTP ${response.status}）`,
+      } satisfies ProbeFailure);
+    }
+    console.warn("[llm-models] /models probe failed, falling back to chat probe", {
+      status: response.status,
+      baseUrlHost: safeHost(baseUrl),
+    });
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: `连接失败: ${describeError(error)}`,
+    } satisfies ProbeFailure);
+  }
+
+  const chatUrl = joinProviderUrl(baseUrl, "chat/completions");
+  if (!chatUrl) {
+    return NextResponse.json({ ok: false, error: "Invalid Base URL" }, { status: 400 });
+  }
+
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+    const response = await fetch(chatUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: probeModel || FALLBACK_PROBE_MODEL,
+        messages: [{ role: "user", content: "hi" }],
+        max_tokens: 1,
+      }),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeoutId));
+
+    if (response.ok) {
+      return NextResponse.json({
+        ok: true,
+        models: probeModel ? [probeModel] : [],
+        fellBackToChatProbe: true,
+      } satisfies ProbeSuccess);
+    }
+
+    const text = await response.text().catch(() => "");
+    return NextResponse.json({
+      ok: false,
+      error: `验证失败（HTTP ${response.status}）: ${text.slice(0, 300)}`,
+    } satisfies ProbeFailure);
+  } catch (error) {
+    return NextResponse.json({
+      ok: false,
+      error: `连接失败: ${describeError(error)}`,
+    } satisfies ProbeFailure);
+  }
+}
+
+function extractModelIds(data: unknown): string[] {
+  if (typeof data !== "object" || data === null) return [];
+  const list = (data as { data?: unknown }).data;
+  if (!Array.isArray(list)) return [];
+  return list
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (typeof item === "object" && item !== null && typeof (item as { id?: unknown }).id === "string") {
+        return (item as { id: string }).id;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .slice(0, MAX_MODELS);
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof Error && error.name === "AbortError") {
+    return `请求超时（${PROBE_TIMEOUT_MS / 1000}s）`;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+function safeHost(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return "invalid";
+  }
+}

--- a/src/app/api/tts/route.ts
+++ b/src/app/api/tts/route.ts
@@ -4,32 +4,94 @@ import {
   GAME_SESSION_EXPIRED_CODE,
   GAME_SESSION_EXPIRED_MESSAGE,
 } from "@/lib/game-session-policy";
-import type { IncomingHttpHeaders } from "node:http";
-import * as https from "node:https";
-import { URL } from "node:url";
-import * as zlib from "node:zlib";
-import { DEFAULT_VOICE_ID } from "@/lib/voice-constants";
+import { bufferToArrayBuffer, sniffAudioMime } from "@/lib/tts/audio-util";
+import { getTtsAdapter, isTtsProviderId } from "@/lib/tts/registry";
+import type { TtsCredentials, TtsProviderId } from "@/lib/tts/types";
+import { TtsProviderError } from "@/lib/tts/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+const PROBE_TEXT = "你好，欢迎来到狼人杀。";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+interface ResolvedTtsRequest {
+  provider: TtsProviderId;
+  credentials: TtsCredentials;
+  /** 是否使用玩家自带的 TTS 配置（为 false 时走服务端环境变量，需要校验对局授权） */
+  hasCustomCredentials: boolean;
+}
+
+function resolveTtsRequest(req: NextRequest): ResolvedTtsRequest | { error: NextResponse } {
+  const providerHeader = req.headers.get("x-tts-provider")?.trim() ?? "";
+
+  // 新协议：显式指定 provider，凭据从 x-tts-* 头读取
+  if (providerHeader) {
+    if (!isTtsProviderId(providerHeader)) {
+      return {
+        error: NextResponse.json({ error: `Unknown TTS provider: ${providerHeader}` }, { status: 400 }),
+      };
+    }
+    const credentials: TtsCredentials = {
+      apiKey: req.headers.get("x-tts-api-key")?.trim() || undefined,
+      baseUrl: req.headers.get("x-tts-base-url")?.trim() || undefined,
+      model: req.headers.get("x-tts-model")?.trim() || undefined,
+      appId: req.headers.get("x-tts-app-id")?.trim() || undefined,
+      accessToken: req.headers.get("x-tts-access-token")?.trim() || undefined,
+    };
+    return {
+      provider: providerHeader,
+      credentials,
+      hasCustomCredentials: true,
+    };
+  }
+
+  // 旧协议：MiniMax 自带 key
+  const headerApiKey = req.headers.get("x-minimax-api-key")?.trim();
+  const headerGroupId = req.headers.get("x-minimax-group-id")?.trim();
+  if (headerApiKey || headerGroupId) {
+    if (!headerApiKey || !headerGroupId) {
+      return {
+        error: NextResponse.json(
+          { error: "MiniMax API key and group ID are both required" },
+          { status: 400 },
+        ),
+      };
+    }
+    return {
+      provider: "minimax",
+      credentials: { apiKey: headerApiKey, groupId: headerGroupId },
+      hasCustomCredentials: true,
+    };
+  }
+
+  // 项目模式：服务端环境变量（仅 MiniMax 有 env 兜底）
+  const envApiKey = process.env.MINIMAX_API_KEY;
+  const envGroupId = process.env.MINIMAX_GROUP_ID;
+  if (!envApiKey || !envGroupId) {
+    return {
+      error: NextResponse.json({ error: "Server configuration error" }, { status: 500 }),
+    };
+  }
+  return {
+    provider: "minimax",
+    credentials: { apiKey: envApiKey, groupId: envGroupId },
+    hasCustomCredentials: false,
+  };
 }
 
 export async function POST(req: NextRequest) {
   const auth = await authenticateRequest(req as unknown as Request);
   if ("error" in auth) return auth.error;
 
-  const headerApiKey = req.headers.get("x-minimax-api-key")?.trim();
-  const headerGroupId = req.headers.get("x-minimax-group-id")?.trim();
-  const hasCustomTtsKey = Boolean(headerApiKey || headerGroupId);
+  const resolved = resolveTtsRequest(req);
+  if ("error" in resolved) return resolved.error;
+  const { provider, credentials, hasCustomCredentials } = resolved;
 
-  if (hasCustomTtsKey && (!headerApiKey || !headerGroupId)) {
-    return NextResponse.json({ error: "MiniMax API key and group ID are both required" }, { status: 400 });
-  }
-
-  if (!hasCustomTtsKey) {
+  if (!hasCustomCredentials) {
     const sessionId = req.headers.get("x-game-session-id")?.trim() || null;
     const hasAuthorizedSession = await hasAuthorizedActiveGameSession(auth.user.id, sessionId);
     if (!hasAuthorizedSession) {
@@ -48,6 +110,12 @@ export async function POST(req: NextRequest) {
     const parsedRecord = isRecord(parsed) ? parsed : {};
     const text = typeof parsedRecord.text === "string" ? parsedRecord.text : String(parsedRecord.text ?? "");
     const voiceId = typeof parsedRecord.voiceId === "string" ? parsedRecord.voiceId : String(parsedRecord.voiceId ?? "");
+    const probe = parsedRecord.probe === true;
+    const locale = parsedRecord.locale === "en" ? "en" : "zh";
+
+    if (probe) {
+      return await handleProbe(provider, credentials, locale);
+    }
 
     const normText = text.trim();
     const normVoiceId = voiceId.trim();
@@ -56,370 +124,82 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Missing text or voiceId" }, { status: 400 });
     }
 
-    const apiKey = hasCustomTtsKey ? headerApiKey : process.env.MINIMAX_API_KEY;
-    const groupId = hasCustomTtsKey ? headerGroupId : process.env.MINIMAX_GROUP_ID;
+    const adapter = getTtsAdapter(provider);
+    const { audio } = await adapter.synthesize(
+      { text: normText, voiceId: normVoiceId, locale },
+      credentials,
+    );
 
-    if (!apiKey || !groupId) {
-      console.error("Missing MiniMax credentials");
-      return NextResponse.json({ error: "Server configuration error" }, { status: 500 });
-    }
-
-    // MiniMax T2A V2 API Endpoint
-    // 参考文档：https://platform.minimaxi.com/document/T2A%20V2
-    const baseUrlFromEnv = process.env.MINIMAX_API_BASE_URL;
-    const primaryBaseUrl = baseUrlFromEnv || "https://api.minimax.chat";
-
-    const candidateBaseUrls = [primaryBaseUrl];
-    if (!baseUrlFromEnv) {
-      // 自动兜底另一个域名，避免因为平台（minimax.chat vs minimaxi.com）差异导致连不通
-      candidateBaseUrls.push(
-        primaryBaseUrl.includes("minimaxi.com")
-          ? "https://api.minimax.chat"
-          : "https://api.minimaxi.com"
+    const sniff = sniffAudioMime(audio);
+    if (!sniff.mime) {
+      const preview = audio.slice(0, 400).toString("utf8");
+      return NextResponse.json(
+        {
+          error: "TTS audio is not in a supported format.",
+          reason: sniff.reason,
+          byteLength: audio.length,
+          preview,
+        },
+        { status: 502 },
       );
     }
 
-    const payload = {
-      model: process.env.MINIMAX_TTS_MODEL || "speech-01-turbo",
-      text: normText,
-      stream: false, // 暂时不使用流式，简化前端处理
-      voice_setting: {
-        voice_id: normVoiceId,
-        speed: 1.0,
-        vol: 1.0,
-        pitch: 0,
+    return new NextResponse(bufferToArrayBuffer(audio), {
+      headers: {
+        "Content-Type": sniff.mime,
+        "Content-Length": audio.length.toString(),
+        "X-TTS-Provider": provider,
+        "X-TTS-Voice-Requested": normVoiceId,
       },
-      audio_setting: {
-        sample_rate: 32000,
-        bitrate: 128000,
-        format: "mp3",
-        channel: 1,
-      },
-    };
-
-    const requestBuffer = async (inputUrl: string, init: {
-      method: "GET" | "POST";
-      headers?: Record<string, string>;
-      body?: string;
-      timeoutMs: number;
-    }): Promise<{ statusCode: number; headers: IncomingHttpHeaders; body: Buffer }> => {
-      const u = new URL(inputUrl);
-      if (u.protocol !== "https:") {
-        throw new Error(`Unsupported protocol: ${u.protocol}`);
-      }
-
-      return await new Promise((resolve, reject) => {
-        const req2 = https.request(
-          {
-            protocol: u.protocol,
-            hostname: u.hostname,
-            port: u.port ? Number(u.port) : 443,
-            path: `${u.pathname}${u.search}`,
-            method: init.method,
-            headers: init.headers,
-            family: 4,
-          },
-          (res) => {
-            const chunks: Buffer[] = [];
-            res.on("data", (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
-            res.on("end", () => {
-              const raw = Buffer.concat(chunks);
-
-              const enc = res.headers["content-encoding"];
-              const encStr = Array.isArray(enc) ? enc.join(",") : enc;
-
-              let body = raw;
-              try {
-                if (typeof encStr === "string" && encStr) {
-                  const e = encStr.toLowerCase();
-                  if (e.includes("br")) body = zlib.brotliDecompressSync(raw);
-                  else if (e.includes("gzip")) body = zlib.gunzipSync(raw);
-                  else if (e.includes("deflate")) body = zlib.inflateSync(raw);
-                }
-              } catch (decompressErr) {
-                // 解压失败就回退到原始内容，并在上层用可读错误定位
-                console.error("MiniMax response decompress failed:", decompressErr);
-                body = raw;
-              }
-
-              resolve({
-                statusCode: res.statusCode || 0,
-                headers: res.headers,
-                body,
-              });
-            });
-          }
-        );
-
-        req2.on("error", reject);
-        req2.setTimeout(init.timeoutMs, () => {
-          req2.destroy(new Error("RequestTimeout"));
-        });
-
-        if (init.body) req2.write(init.body);
-        req2.end();
-      });
-    };
-
-    const bufferToArrayBuffer = (b: Buffer): ArrayBuffer => {
-      const ab = new ArrayBuffer(b.byteLength);
-      new Uint8Array(ab).set(b);
-      return ab;
-    };
-
-    const sniffAudioMime = (b: Buffer): { mime: string | null; reason?: string } => {
-      if (!b || b.length < 4) return { mime: null, reason: "empty_or_too_short" };
-
-      // WAV: RIFF....WAVE
-      if (b.length >= 12 && b.slice(0, 4).toString("ascii") === "RIFF" && b.slice(8, 12).toString("ascii") === "WAVE") {
-        return { mime: "audio/wav" };
-      }
-
-      // OGG
-      if (b.slice(0, 4).toString("ascii") === "OggS") {
-        return { mime: "audio/ogg" };
-      }
-
-      // MP3: ID3 tag or frame sync 0xFFE?
-      if (b.slice(0, 3).toString("ascii") === "ID3") {
-        return { mime: "audio/mpeg" };
-      }
-      if (b[0] === 0xff && (b[1] & 0xe0) === 0xe0) {
-        return { mime: "audio/mpeg" };
-      }
-
-      // If it looks like text/json, treat as non-audio
-      const head = b.slice(0, 64).toString("utf8").trim();
-      if (head.startsWith("{") || head.startsWith("[") || head.toLowerCase().includes("error")) {
-        return { mime: null, reason: "looks_like_text_or_json" };
-      }
-
-      return { mime: null, reason: "unknown_format" };
-    };
-
-    const respondAudio = (b: Buffer, extraHeaders?: Record<string, string>) => {
-      const sniff = sniffAudioMime(b);
-      if (!sniff.mime) {
-        const preview = b.slice(0, 400).toString("utf8");
-        return NextResponse.json(
-          {
-            error: "TTS audio is not in a supported format.",
-            reason: sniff.reason,
-            byteLength: b.length,
-            preview,
-          },
-          { status: 502 }
-        );
-      }
-
-      return new NextResponse(bufferToArrayBuffer(b), {
-        headers: {
-          "Content-Type": sniff.mime,
-          "Content-Length": b.length.toString(),
-          ...(extraHeaders ?? {}),
-        },
-      });
-    };
-
-    const pickFallbackVoiceId = (badVoiceId: string) => {
-      const v = badVoiceId.toLowerCase();
-      if (v.startsWith("female") || v.includes("female")) return DEFAULT_VOICE_ID.female;
-      return DEFAULT_VOICE_ID.male;
-    };
-
-    const requestMiniMax = async (voiceIdForRequest: string) => {
-      payload.voice_setting.voice_id = voiceIdForRequest;
-      let response: { statusCode: number; headers: IncomingHttpHeaders; body: Buffer } | null = null;
-      let lastError: unknown = null;
-
-      for (const baseUrl of candidateBaseUrls) {
-        const url = `${baseUrl}/v1/t2a_v2?GroupId=${encodeURIComponent(groupId)}`;
-
-        try {
-          response = await requestBuffer(url, {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${apiKey}`,
-              "Content-Type": "application/json",
-              GroupId: groupId,
-              "Accept-Encoding": "identity",
-            },
-            body: JSON.stringify(payload),
-            timeoutMs: 30000,
-          });
-          break;
-        } catch (e) {
-          lastError = e;
-          continue;
-        }
-      }
-
-      if (!response) {
-        const attempted = candidateBaseUrls.join(", ");
-        console.error("MiniMax fetch failed. attempted base urls:", attempted, lastError);
-      }
-
-      return response;
-    };
-
-    let usedVoiceId = normVoiceId;
-
-    for (let attempt = 0; attempt < 2; attempt++) {
-      const response = await requestMiniMax(usedVoiceId);
-
-      if (!response) {
-        return NextResponse.json(
-          {
-            error:
-              "MiniMax fetch failed (connect timeout / network). Please set MINIMAX_API_BASE_URL to the correct domain (https://api.minimaxi.com or https://api.minimax.chat) and ensure your network can reach it.",
-            attemptedBaseUrls: candidateBaseUrls,
-          },
-          { status: 502 }
-        );
-      }
-
-      if (response.statusCode < 200 || response.statusCode >= 300) {
-        const errorText = response.body.toString("utf8");
-        console.error("MiniMax API Error:", response.statusCode, errorText);
-        return NextResponse.json({ error: `MiniMax API error: ${errorText}` }, { status: response.statusCode || 502 });
-      }
-
-      const contentType = response.headers["content-type"];
-
-      if (typeof contentType === "string" && contentType.includes("application/json")) {
-        let json: unknown;
-        try {
-          json = JSON.parse(response.body.toString("utf8"));
-        } catch (e) {
-          const preview = response.body.slice(0, 600).toString("utf8");
-          console.error("MiniMax JSON parse failed:", e, { preview });
-          return NextResponse.json(
-            { error: "MiniMax JSON parse failed", preview },
-            { status: 502 }
-          );
-        }
-
-        const jsonRecord = isRecord(json) ? json : {};
-        const baseResp = isRecord(jsonRecord.base_resp) ? jsonRecord.base_resp : null;
-        if (baseResp && baseResp.status_code !== 0) {
-          const code = Number(baseResp.status_code);
-          const msg = String(baseResp.status_msg || "");
-
-          if (code === 2054 && attempt === 0) {
-            const fallback = pickFallbackVoiceId(usedVoiceId);
-            if (fallback !== usedVoiceId) {
-              usedVoiceId = fallback;
-              continue;
-            }
-          }
-
-          console.error("MiniMax base_resp error:", {
-            status_code: code,
-            status_msg: msg,
-            voiceId: usedVoiceId,
-            textPreview: String(normText).slice(0, 200),
-          });
-          return NextResponse.json(
-            {
-              error: "MiniMax base_resp error",
-              status_code: code,
-              status_msg: msg,
-              voiceId: usedVoiceId,
-              textPreview: String(normText).slice(0, 200),
-            },
-            { status: 502 }
-          );
-        }
-
-        const dataRecord = isRecord(jsonRecord.data) ? jsonRecord.data : null;
-        const audioRecord = isRecord(jsonRecord.audio) ? jsonRecord.audio : null;
-        const dataStr: unknown =
-          (typeof jsonRecord.data === "string" ? jsonRecord.data : undefined) ??
-          dataRecord?.audio ??
-          dataRecord?.data ??
-          audioRecord?.data ??
-          jsonRecord.audio_data;
-
-        const audioUrl: unknown = audioRecord?.url ?? dataRecord?.url ?? jsonRecord.url;
-
-        if (typeof audioUrl === "string" && audioUrl.startsWith("http")) {
-          const audioResp = await requestBuffer(audioUrl, {
-            method: "GET",
-            headers: {
-              "Accept-Encoding": "identity",
-            },
-            timeoutMs: 30000,
-          });
-          if (audioResp.statusCode < 200 || audioResp.statusCode >= 300) {
-            return NextResponse.json({ error: `MiniMax audio url fetch failed: ${audioResp.statusCode}` }, { status: 502 });
-          }
-
-          return respondAudio(audioResp.body, {
-            "X-Minimax-Voice-Id-Requested": normVoiceId,
-            "X-Minimax-Voice-Id-Used": usedVoiceId,
-          });
-        }
-
-        if (typeof dataStr === "string" && dataStr.trim()) {
-          const t = dataStr.trim();
-
-          const maybeB64 = t.startsWith("data:") ? t.split(",").slice(1).join(",") : t;
-          const looksLikeBase64 = /[+/=]/.test(maybeB64);
-          const looksLikeHex = !looksLikeBase64 && /^[0-9a-fA-F]+$/.test(t) && t.length % 2 === 0;
-
-          let buffer: Buffer;
-          let altBuffer: Buffer | null = null;
-
-          if (looksLikeHex) {
-            buffer = Buffer.from(t, "hex");
-            try {
-              altBuffer = Buffer.from(maybeB64, "base64");
-            } catch {
-              altBuffer = null;
-            }
-          } else {
-            buffer = Buffer.from(maybeB64, "base64");
-            if (/^[0-9a-fA-F]+$/.test(t) && t.length % 2 === 0) {
-              try {
-                altBuffer = Buffer.from(t, "hex");
-              } catch {
-                altBuffer = null;
-              }
-            }
-          }
-
-          const primarySniff = sniffAudioMime(buffer);
-          if (!primarySniff.mime && altBuffer) {
-            const altSniff = sniffAudioMime(altBuffer);
-            if (altSniff.mime) {
-              buffer = altBuffer;
-            }
-          }
-
-          return respondAudio(buffer, {
-            "X-Minimax-Voice-Id-Requested": normVoiceId,
-            "X-Minimax-Voice-Id-Used": usedVoiceId,
-          });
-        }
-      }
-
-      return respondAudio(response.body, {
-        "X-Minimax-Voice-Id-Requested": normVoiceId,
-        "X-Minimax-Voice-Id-Used": usedVoiceId,
-      });
-    }
-
-    return NextResponse.json(
-      {
-        error: "MiniMax voiceId retry exhausted",
-        voiceId: usedVoiceId,
-        textPreview: String(normText).slice(0, 200),
-      },
-      { status: 502 }
-    );
-
+    });
   } catch (error) {
+    if (error instanceof TtsProviderError) {
+      console.error(`TTS API Error (${provider}):`, error.message, error.detail ?? "");
+      return NextResponse.json(
+        { error: error.message, detail: error.detail, provider },
+        { status: error.status === 400 ? 400 : error.status },
+      );
+    }
     console.error("TTS API Error:", error);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}
+
+/** 连通性测试：用各 Provider 的默认音色合成一句话，返回结果元信息（丢弃音频）。 */
+async function handleProbe(
+  provider: TtsProviderId,
+  credentials: TtsCredentials,
+  locale: "zh" | "en",
+) {
+  const adapter = getTtsAdapter(provider);
+  try {
+    const { audio } = await adapter.synthesize(
+      { text: PROBE_TEXT, voiceId: adapter.defaultVoiceId(locale), locale },
+      credentials,
+    );
+    const sniff = sniffAudioMime(audio);
+    if (!sniff.mime) {
+      return NextResponse.json(
+        { ok: false, error: "TTS 返回了无法识别的音频格式", provider },
+        { status: 502 },
+      );
+    }
+    return NextResponse.json({
+      ok: true,
+      provider,
+      mimeType: sniff.mime,
+      bytes: audio.length,
+    });
+  } catch (error) {
+    if (error instanceof TtsProviderError) {
+      return NextResponse.json(
+        { ok: false, error: error.message, detail: error.detail, provider },
+        { status: 200 },
+      );
+    }
+    return NextResponse.json(
+      { ok: false, error: `连接失败: ${String(error)}`, provider },
+      { status: 200 },
+    );
   }
 }

--- a/src/app/api/vote-batch/route.ts
+++ b/src/app/api/vote-batch/route.ts
@@ -11,7 +11,7 @@ type VoteBatchRequest = {
   reasoning?: { enabled: boolean; effort?: "minimal" | "low" | "medium" | "high"; max_tokens?: number };
   reasoning_effort?: "minimal" | "low" | "medium" | "high";
   response_format?: unknown;
-  provider?: "zenmux" | "dashscope" | "tokendance";
+  provider?: "zenmux" | "dashscope" | "tokendance" | "custom";
 };
 
 export async function POST(request: NextRequest) {
@@ -30,6 +30,8 @@ export async function POST(request: NextRequest) {
     const headerTokendanceKey = request.headers.get("x-tokendance-api-key")?.trim();
     const headerTokendanceBaseUrl = request.headers.get("x-tokendance-base-url")?.trim();
     const headerTokenPayMode = request.headers.get("x-tokenpay-mode")?.trim();
+    const headerCustomBaseUrl = request.headers.get("x-custom-base-url")?.trim();
+    const headerCustomApiKey = request.headers.get("x-custom-api-key")?.trim();
     const headerGameSessionId = request.headers.get("x-game-session-id")?.trim();
     const origin = request.nextUrl.origin;
 
@@ -43,6 +45,8 @@ export async function POST(request: NextRequest) {
         ...(headerTokendanceKey ? { "X-Tokendance-Api-Key": headerTokendanceKey } : {}),
         ...(headerTokendanceBaseUrl ? { "X-Tokendance-Base-Url": headerTokendanceBaseUrl } : {}),
         ...(headerTokenPayMode ? { "X-TokenPay-Mode": headerTokenPayMode } : {}),
+        ...(headerCustomBaseUrl ? { "X-Custom-Base-Url": headerCustomBaseUrl } : {}),
+        ...(headerCustomApiKey ? { "X-Custom-Api-Key": headerCustomApiKey } : {}),
         ...(headerGameSessionId ? { "X-Game-Session-Id": headerGameSessionId } : {}),
         Authorization: request.headers.get("Authorization") || "",
       },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,7 +55,8 @@ import { TokenPayRecoveryHost } from "@/components/game/TokenPayRecoveryHost";
 import { buildSimpleAvatarUrl, getModelLogoUrl } from "@/lib/avatar-config";
 import { audioManager, makeAudioTaskId } from "@/lib/audio-manager";
 import { getNarratorPlayer } from "@/lib/narrator-audio-player";
-import { resolveVoiceId, type AppLocale } from "@/lib/voice-constants";
+import { type AppLocale } from "@/lib/voice-constants";
+import { resolveVoiceIdForActiveProvider } from "@/lib/tts-client";
 import { getLocale } from "@/i18n/locale-store";
 import { useSettings } from "@/hooks/useSettings";
 import { useTutorial } from "@/hooks/useTutorial";
@@ -664,11 +665,12 @@ export default function Home() {
 
     const player = gameState.players.find((p) => p.displayName === currentDialogue.speaker);
     const locale = getLocale() as AppLocale;
-    const voiceId = resolveVoiceId(
+    const voiceId = resolveVoiceIdForActiveProvider(
       player?.agentProfile?.persona?.voiceId,
       player?.agentProfile?.persona?.gender,
       player?.agentProfile?.persona?.age,
-      locale
+      locale,
+      player?.playerId,
     );
     const taskId = makeAudioTaskId(voiceId, text);
     const durationMs = audioManager.getCachedDurationMs(taskId);

--- a/src/components/DevTools/DevConsole.tsx
+++ b/src/components/DevTools/DevConsole.tsx
@@ -19,7 +19,9 @@ import {
   type SmartJumpResult,
 } from "@/lib/SmartJumpManager";
 import { PhaseManager } from "@/game/core/PhaseManager";
-import { DEFAULT_VOICE_ID, resolveVoiceId, VOICE_PRESETS, ENGLISH_VOICE_PRESETS, type AppLocale } from "@/lib/voice-constants";
+import { DEFAULT_VOICE_ID, VOICE_PRESETS, ENGLISH_VOICE_PRESETS, type AppLocale } from "@/lib/voice-constants";
+import { resolveVoiceIdForActiveProvider } from "@/lib/tts-client";
+import { buildTtsRequestHeaders } from "@/lib/tts-client";
 import { getLocale } from "@/i18n/locale-store";
 import { aiLogger } from "@/lib/ai-logger";
 import { useGameAnalysis } from "@/hooks/useGameAnalysis";
@@ -161,7 +163,10 @@ function TTSTab() {
     try {
       const res = await fetch("/api/tts", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          ...buildTtsRequestHeaders(),
+        },
         body: JSON.stringify({ text, voiceId }),
       });
 
@@ -1631,11 +1636,12 @@ function PlayersTab({
                   <span className="text-xs text-yellow-400 font-mono">
                     {(() => {
                       const locale = getLocale() as AppLocale;
-                      const voiceId = resolveVoiceId(
+                      const voiceId = resolveVoiceIdForActiveProvider(
                         selectedPlayer.agentProfile?.persona?.voiceId,
                         selectedPlayer.agentProfile?.persona?.gender,
                         selectedPlayer.agentProfile?.persona?.age,
-                        locale
+                        locale,
+                        selectedPlayer.playerId,
                       );
                       const presets = locale === "en" ? ENGLISH_VOICE_PRESETS : VOICE_PRESETS;
                       const preset = presets.find((p) => p.id === voiceId);

--- a/src/components/game/UserProfileModal.tsx
+++ b/src/components/game/UserProfileModal.tsx
@@ -33,6 +33,7 @@ import {
   getValidatedZenmuxKey,
   getValidatedDashscopeKey,
   getValidatedTokendanceKey,
+  hasActiveCustomLlmKey,
   hasDashscopeKey,
   hasTokendanceKey,
   hasZenmuxKey,
@@ -53,6 +54,9 @@ import {
   type ModelSource,
 } from "@/lib/api-keys";
 import { getModelLogoPath } from "@/lib/model-logo";
+import { getCustomModelRefs, listCustomLlmProviders } from "@/lib/custom-providers";
+import { CustomLlmProviderPanel } from "@/components/game/settings/CustomLlmProviderPanel";
+import { TtsProviderPanel } from "@/components/game/settings/TtsProviderPanel";
 import { supabase } from "@/lib/supabase";
 import { REFERRAL_BONUS_ENABLED, SPRING_CAMPAIGN_ENABLED, REDEMPTION_CODE_ENABLED } from "@/lib/welfare-config";
 import { TokenPayPanel } from "@/components/game/TokenPayPanel";
@@ -116,6 +120,7 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
   const [tokendanceKey, setTokendanceKeyState] = useState("");
   const [minimaxKey, setMinimaxKeyState] = useState("");
   const [minimaxGroupId, setMinimaxGroupIdState] = useState("");
+  const [customProvidersVersion, setCustomProvidersVersion] = useState(0);
   const [showZenmuxKey, setShowZenmuxKey] = useState(false);
   const [showDashscopeKey, setShowDashscopeKey] = useState(false);
   const [showTokendanceKey, setShowTokendanceKey] = useState(false);
@@ -152,6 +157,7 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
   const getProviderLabel = (provider: ModelRef["provider"]) => {
     if (provider === "zenmux") return "Zenmux";
     if (provider === "tokendance") return "TokenDance";
+    if (provider === "custom") return t("customProviders.short");
     return t("customKey.dashscope.short");
   };
 
@@ -208,9 +214,14 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
   const zenmuxConfigured = Boolean(zenmuxKey.trim());
   const dashscopeConfigured = Boolean(dashscopeKey.trim());
   const tokendanceConfigured = hasTokendanceKey();
+  const customModelRefs = useMemo(
+    () => getCustomModelRefs(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [customProvidersVersion],
+  );
   const modelPool = useMemo(() => {
-    return ALL_MODELS;
-  }, []);
+    return customModelRefs.length > 0 ? [...ALL_MODELS, ...customModelRefs] : ALL_MODELS;
+  }, [customModelRefs]);
   const defaultModelPool = useMemo(() => {
     return AVAILABLE_MODELS;
   }, []);
@@ -219,9 +230,10 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
     if (zenmuxConfigured) providers.add("zenmux");
     if (dashscopeConfigured) providers.add("dashscope");
     if (tokendanceConfigured) providers.add("tokendance");
+    if (customModelRefs.length > 0) providers.add("custom");
     if (providers.size === 0) return [];
     return modelPool.filter((ref) => providers.has(ref.provider));
-  }, [dashscopeConfigured, modelPool, tokendanceConfigured, zenmuxConfigured]);
+  }, [customModelRefs, dashscopeConfigured, modelPool, tokendanceConfigured, zenmuxConfigured]);
   const defaultAvailableModels = useMemo(() => {
     const providers = new Set<ModelRef["provider"]>();
     if (zenmuxConfigured) providers.add("zenmux");
@@ -230,6 +242,7 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
     if (providers.size === 0) return [];
     return defaultModelPool.filter((ref) => providers.has(ref.provider));
   }, [dashscopeConfigured, defaultModelPool, tokendanceConfigured, zenmuxConfigured]);
+  const handleCustomProvidersChanged = () => setCustomProvidersVersion((v) => v + 1);
   const playerModelPool = useMemo(() => {
     return filterPlayerModels(availableModelPool);
   }, [availableModelPool]);
@@ -565,6 +578,7 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
             <TabsTrigger value="payAsYouGo">{t("customKey.tabs.payAsYouGo")}</TabsTrigger>
             <TabsTrigger value="tokenpay">{t("customKey.tabs.tokenPay")}</TabsTrigger>
             <TabsTrigger value="custom">{t("customKey.tabs.custom")}</TabsTrigger>
+            <TabsTrigger value="tts">{t("ttsProvider.tab")}</TabsTrigger>
           </TabsList>
 
           <TabsContent value="profile">
@@ -817,7 +831,13 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
                     checked={showCustomKeySettings}
                     onCheckedChange={(value) => {
                       if (value) {
-                        if (hasZenmuxKey() || hasDashscopeKey() || hasTokendanceKey()) {
+                        if (
+                          hasZenmuxKey() ||
+                          hasDashscopeKey() ||
+                          hasTokendanceKey() ||
+                          hasActiveCustomLlmKey() ||
+                          listCustomLlmProviders().length > 0
+                        ) {
                           changeModelSource("custom");
                         } else {
                           changeModelSource("project");
@@ -831,6 +851,9 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
                   />
                 </div>
               </section>
+
+              {/* 1.5 自定义 OpenAI 兼容 Provider：始终可见，避免“没有 key 就看不到面板”的死锁 */}
+              <CustomLlmProviderPanel onProvidersChanged={handleCustomProvidersChanged} />
 
               {showCustomKeySettings && (
                 <>
@@ -1130,6 +1153,9 @@ import type { SpringCampaignSnapshot } from "@/lib/spring-campaign";
                 </>
               )}
             </div>
+          </TabsContent>
+          <TabsContent value="tts">
+            <TtsProviderPanel />
           </TabsContent>
         </Tabs>
       </DialogContent>

--- a/src/components/game/WelcomeScreen.tsx
+++ b/src/components/game/WelcomeScreen.tsx
@@ -34,6 +34,8 @@ import {
   setModelSource,
   syncTokenPayConnectionState,
   type ModelSource,
+
+  hasActiveCustomLlmKey,
 } from "@/lib/api-keys";
 import { loadTokenPayConnectionWithRetry } from "@/lib/tokenpay-client";
 import { useAppLocale } from "@/i18n/useAppLocale";
@@ -748,7 +750,7 @@ export function WelcomeScreen({
 
   const hasActiveExternalModelSource = () => (
     (getModelSource() === "custom" &&
-      (hasZenmuxKey() || hasDashscopeKey() || hasTokendanceKey())) ||
+      (hasZenmuxKey() || hasDashscopeKey() || hasTokendanceKey() || hasActiveCustomLlmKey())) ||
     (getModelSource() === "tokenpay" && (tokenPayConnected || isTokenPayConnected()))
   );
 

--- a/src/components/game/settings/CustomLlmProviderPanel.tsx
+++ b/src/components/game/settings/CustomLlmProviderPanel.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Check, Eye, EyeSlash, PencilSimple, Plus, TrashSimple, ArrowUUpLeft } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import {
+  deleteCustomLlmProvider,
+  generateProviderId,
+  LLM_PROVIDER_PRESETS,
+  listCustomLlmProviders,
+  probeCustomLlmProvider,
+  saveCustomLlmProvider,
+  setActiveCustomLlmProviderId,
+  getActiveCustomLlmProviderId,
+  type CustomLlmProvider,
+} from "@/lib/custom-providers";
+
+interface CustomLlmProviderPanelProps {
+  onProvidersChanged: () => void;
+}
+
+interface DraftProvider {
+  id: string;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+}
+
+const emptyDraft = (): DraftProvider => ({
+  id: "",
+  name: "",
+  baseUrl: "",
+  apiKey: "",
+});
+
+export function CustomLlmProviderPanel({ onProvidersChanged }: CustomLlmProviderPanelProps) {
+  const t = useTranslations("customProviders");
+  const [providers, setProviders] = useState<CustomLlmProvider[]>([]);
+  const [activeId, setActiveIdState] = useState<string | null>(null);
+  const [draft, setDraft] = useState<DraftProvider | null>(null);
+  const [showKey, setShowKey] = useState(false);
+  const [probing, setProbing] = useState(false);
+  const [probedModelIds, setProbedModelIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setProviders(listCustomLlmProviders());
+    setActiveIdState(getActiveCustomLlmProviderId());
+  }, []);
+
+  const refresh = () => {
+    setProviders(listCustomLlmProviders());
+    setActiveIdState(getActiveCustomLlmProviderId());
+    onProvidersChanged();
+  };
+
+  const handleProbe = async () => {
+    if (!draft || probing || !draft.baseUrl.trim() || !draft.apiKey.trim()) return;
+    setProbing(true);
+    try {
+      const result = await probeCustomLlmProvider({
+        baseUrl: draft.baseUrl,
+        apiKey: draft.apiKey,
+      });
+      if (result.ok) {
+        setProbedModelIds(result.models ?? []);
+        const count = result.models?.length ?? 0;
+        if (result.fellBackToChatProbe) {
+          toast.success(t("toasts.probeOkFallback"));
+        } else if (count > 0) {
+          toast.success(t("toasts.probeOkModels", { count }));
+        } else {
+          toast.success(t("toasts.probeOkNoModels"));
+        }
+      } else {
+        setProbedModelIds([]);
+        toast.error(t("toasts.probeFail"), { description: result.error });
+      }
+    } finally {
+      setProbing(false);
+    }
+  };
+
+  const handleSave = () => {
+    if (!draft) return;
+    if (!draft.baseUrl.trim() || !draft.apiKey.trim()) {
+      toast.error(t("toasts.missingFields"));
+      return;
+    }
+    const providerId = draft.id || generateProviderId();
+    saveCustomLlmProvider({
+      id: providerId,
+      name: draft.name,
+      baseUrl: draft.baseUrl,
+      apiKey: draft.apiKey,
+      modelIds: probedModelIds,
+    });
+    // 保存即自动设为使用中：否则用户只有保存、没有激活，开局依然回落到
+    // 项目积分扣费分支（active 为空时 buildCustomProviderHeaders 拿不到凭据）
+    if (!getActiveCustomLlmProviderId() || getActiveCustomLlmProviderId() === providerId) {
+      setActiveCustomLlmProviderId(providerId);
+    }
+    setDraft(null);
+    setProbedModelIds([]);
+    refresh();
+    toast.success(t("toasts.saved"));
+  };
+
+  const handleDelete = (id: string) => {
+    deleteCustomLlmProvider(id);
+    refresh();
+    toast.success(t("toasts.deleted"));
+  };
+
+  const handleSetActive = (id: string | null) => {
+    setActiveCustomLlmProviderId(id);
+    refresh();
+  };
+
+  const startEdit = (provider: CustomLlmProvider) => {
+    setDraft({
+      id: provider.id,
+      name: provider.name,
+      baseUrl: provider.baseUrl,
+      apiKey: provider.apiKey,
+    });
+    setProbedModelIds(provider.modelIds);
+    setShowKey(false);
+  };
+
+  return (
+    <section className="rounded-lg border border-[var(--border-color)] bg-[var(--bg-card)] p-4 space-y-4">
+      <div>
+        <h3 className="text-sm font-medium text-[var(--text-primary)]">{t("title")}</h3>
+        <p className="text-xs text-[var(--text-muted)] mt-1">{t("description")}</p>
+      </div>
+
+      {/* 已保存的 Provider 列表 */}
+      {providers.length > 0 && (
+        <div className="space-y-2">
+          {providers.map((provider) => {
+            const isActive = provider.id === activeId;
+            return (
+              <div
+                key={provider.id}
+                className={`rounded-md border px-3 py-2.5 ${
+                  isActive
+                    ? "border-[var(--color-accent)] bg-[var(--color-accent-bg)]"
+                    : "border-[var(--border-color)] bg-[var(--bg-secondary)]"
+                }`}
+              >
+                <div className="flex items-center gap-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-xs font-medium text-[var(--text-primary)] truncate">{provider.name}</span>
+                      {isActive && (
+                        <span className="rounded bg-[var(--color-accent)] px-1.5 py-0.5 text-[10px] font-medium text-white shrink-0">
+                          {t("activeBadge")}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-[11px] text-[var(--text-muted)] truncate mt-0.5">
+                      {provider.baseUrl}
+                      {provider.modelIds.length > 0 && ` · ${t("modelCount", { count: provider.modelIds.length })}`}
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleSetActive(isActive ? null : provider.id)}
+                    title={isActive ? t("deactivate") : t("activate")}
+                  >
+                    {isActive ? <ArrowUUpLeft size={14} /> : <Check size={14} />}
+                  </Button>
+                  <Button type="button" variant="outline" size="sm" onClick={() => startEdit(provider)} aria-label={t("edit")}>
+                    <PencilSimple size={14} />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleDelete(provider.id)}
+                    aria-label={t("delete")}
+                    className="text-[var(--color-danger, #ef4444)]"
+                  >
+                    <TrashSimple size={14} />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {!draft ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            setDraft(emptyDraft());
+            setProbedModelIds([]);
+            setShowKey(false);
+          }}
+        >
+          <Plus size={14} className="mr-1" />
+          {t("add")}
+        </Button>
+      ) : (
+        <div className="space-y-3 rounded-md border border-[var(--border-color)] bg-[var(--bg-secondary)] p-3">
+          <div className="space-y-1.5">
+            <Label className="text-xs">{t("preset")}</Label>
+            <Select
+              value=""
+              onValueChange={(key) => {
+                const preset = LLM_PROVIDER_PRESETS.find((p) => p.key === key);
+                if (!preset) return;
+                setDraft((prev) =>
+                  prev
+                    ? {
+                        ...prev,
+                        name: preset.key === "custom" ? prev.name || "" : preset.name,
+                        baseUrl: preset.baseUrl,
+                      }
+                    : prev,
+                );
+              }}
+            >
+              <SelectTrigger className="h-8 text-xs">
+                <SelectValue placeholder={t("presetPlaceholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                {LLM_PROVIDER_PRESETS.map((preset) => (
+                  <SelectItem key={preset.key} value={preset.key} className="text-xs">
+                    {preset.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="custom-llp-name" className="text-xs">{t("name")}</Label>
+            <Input
+              id="custom-llp-name"
+              value={draft.name}
+              onChange={(e) => setDraft((prev) => (prev ? { ...prev, name: e.target.value } : prev))}
+              placeholder={t("namePlaceholder")}
+              className="h-8 text-xs"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="custom-llp-baseurl" className="text-xs">{t("baseUrl")}</Label>
+            <Input
+              id="custom-llp-baseurl"
+              value={draft.baseUrl}
+              onChange={(e) => setDraft((prev) => (prev ? { ...prev, baseUrl: e.target.value } : prev))}
+              placeholder="https://api.deepseek.com/v1"
+              className="h-8 text-xs font-mono"
+            />
+            <p className="text-[11px] text-[var(--text-muted)]">{t("baseUrlHint")}</p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="custom-llp-key" className="text-xs">{t("apiKey")}</Label>
+            <div className="flex gap-2">
+              <Input
+                id="custom-llp-key"
+                type={showKey ? "text" : "password"}
+                autoComplete="new-password"
+                value={draft.apiKey}
+                onChange={(e) => setDraft((prev) => (prev ? { ...prev, apiKey: e.target.value } : prev))}
+                className="flex-1 h-8 text-xs"
+              />
+              <Button type="button" variant="outline" size="sm" onClick={() => setShowKey((v) => !v)} aria-label={showKey ? t("hideKey") : t("showKey")}>
+                {showKey ? <EyeSlash size={14} /> : <Eye size={14} />}
+              </Button>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={handleProbe}
+              disabled={probing || !draft.baseUrl.trim() || !draft.apiKey.trim()}
+            >
+              {probing ? t("probing") : t("probe")}
+            </Button>
+            <Button type="button" size="sm" onClick={handleSave} disabled={!draft.baseUrl.trim() || !draft.apiKey.trim()}>
+              {t("save")}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setDraft(null);
+                setProbedModelIds([]);
+              }}
+            >
+              {t("cancel")}
+            </Button>
+          </div>
+
+          {probedModelIds.length > 0 && (
+            <p className="text-[11px] text-[var(--text-muted)]">
+              {t("modelsPreview", { count: probedModelIds.length })}: {probedModelIds.slice(0, 5).join(", ")}
+              {probedModelIds.length > 5 ? "…" : ""}
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/game/settings/TtsProviderPanel.tsx
+++ b/src/components/game/settings/TtsProviderPanel.tsx
@@ -1,0 +1,348 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Check, SpeakerHigh } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import { getLocale } from "@/i18n/locale-store";
+import type { AppLocale } from "@/lib/voice-constants";
+import {
+  buildTtsRequestHeaders,
+  getTtsSettings,
+  getVoicePresetsForProvider,
+  isCustomTtsActive,
+  probeTtsProvider,
+  saveTtsSettings,
+  TTS_PROVIDER_LABELS,
+  type TtsProviderId,
+  type TtsSettings,
+} from "@/lib/tts-client";
+
+export function TtsProviderPanel() {
+  const t = useTranslations("ttsProvider");
+  const [settings, setSettings] = useState<TtsSettings | null>(null);
+  const [probing, setProbing] = useState(false);
+  const [previewingVoice, setPreviewingVoice] = useState<string | null>(null);
+  const [locale, setLocale] = useState<AppLocale>("zh");
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const objectUrlRef = useRef<string>("");
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    setSettings(getTtsSettings());
+    setLocale((getLocale() as AppLocale) === "en" ? "en" : "zh");
+    return () => {
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    };
+  }, []);
+
+  if (!settings) return null;
+
+  const update = (patch: Partial<TtsSettings>) => {
+    setSettings((prev) => (prev ? { ...prev, ...patch } : prev));
+  };
+
+  const handleSave = () => {
+    saveTtsSettings(settings);
+    toast.success(t("toasts.saved"));
+  };
+
+  const handleProbe = async () => {
+    if (probing) return;
+    setProbing(true);
+    try {
+      const result = await probeTtsProvider(settings);
+      if (result.ok) {
+        toast.success(t("toasts.probeOk"));
+      } else {
+        toast.error(t("toasts.probeFail"), { description: result.error });
+      }
+    } finally {
+      setProbing(false);
+    }
+  };
+
+  const handlePreview = async (voiceId: string) => {
+    if (previewingVoice) return;
+    setPreviewingVoice(voiceId);
+    try {
+      const response = await fetch("/api/tts", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...buildTtsRequestHeaders(settings),
+        },
+        body: JSON.stringify({
+          text: locale === "zh" ? "你好，我是狼人杀里的一个角色。" : "Hello, I am a character in this game of Werewolf.",
+          voiceId,
+          locale,
+        }),
+      });
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as { error?: string } | null;
+        toast.error(t("toasts.previewFail"), { description: data?.error || `HTTP ${response.status}` });
+        return;
+      }
+      const blob = await response.blob();
+      if (blob.type.includes("json") || blob.type.includes("text")) {
+        const text = await blob.text();
+        let message = text.slice(0, 300);
+        try {
+          message = (JSON.parse(text) as { error?: string }).error ?? message;
+        } catch {
+          // keep raw text
+        }
+        toast.error(t("toasts.previewFail"), { description: message });
+        return;
+      }
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+      const url = URL.createObjectURL(blob);
+      objectUrlRef.current = url;
+      if (!audioRef.current) audioRef.current = new Audio();
+      audioRef.current.src = url;
+      await audioRef.current.play();
+    } catch (error) {
+      toast.error(t("toasts.previewFail"), {
+        description: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setPreviewingVoice(null);
+    }
+  };
+
+  const provider = settings.provider;
+  const presets = getVoicePresetsForProvider(provider, locale);
+
+  return (
+    <div className="space-y-5">
+      <section className="rounded-lg border border-[var(--border-color)] bg-[var(--bg-card)] p-4 space-y-4">
+        <div>
+          <h3 className="text-sm font-medium text-[var(--text-primary)]">{t("title")}</h3>
+          <p className="text-xs text-[var(--text-muted)] mt-1">{t("description")}</p>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label className="text-xs">{t("provider")}</Label>
+          <Select
+            value={provider}
+            onValueChange={(value: TtsProviderId) => update({ provider: value })}
+          >
+            <SelectTrigger className="h-9 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(Object.keys(TTS_PROVIDER_LABELS) as TtsProviderId[]).map((id) => (
+                <SelectItem key={id} value={id} className="text-xs">
+                  {locale === "zh" ? TTS_PROVIDER_LABELS[id].zh : TTS_PROVIDER_LABELS[id].en}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {provider === "minimax" && (
+          <p className="text-xs text-[var(--text-muted)]">{t("minimaxNote")}</p>
+        )}
+
+        {provider === "stepfun" && (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-step-baseurl" className="text-xs">{t("stepfun.baseUrl")}</Label>
+              <Input
+                id="tts-step-baseurl"
+                value={settings.stepfun.baseUrl}
+                onChange={(e) => update({ stepfun: { ...settings.stepfun, baseUrl: e.target.value } })}
+                placeholder="https://api.stepfun.com/v1"
+                className="h-8 text-xs font-mono"
+              />
+              <p className="text-[11px] text-[var(--text-muted)]">{t("stepfun.baseUrlHint")}</p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-step-key" className="text-xs">{t("apiKey")}</Label>
+              <Input
+                id="tts-step-key"
+                type="password"
+                autoComplete="new-password"
+                value={settings.stepfun.apiKey}
+                onChange={(e) => update({ stepfun: { ...settings.stepfun, apiKey: e.target.value } })}
+                className="h-8 text-xs"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-step-model" className="text-xs">{t("stepfun.model")}</Label>
+              <Input
+                id="tts-step-model"
+                value={settings.stepfun.model}
+                onChange={(e) => update({ stepfun: { ...settings.stepfun, model: e.target.value } })}
+                placeholder="step-tts-mini / step-tts-2 / stepaudio-2.5-tts"
+                className="h-8 text-xs font-mono"
+              />
+            </div>
+          </div>
+        )}
+
+        {provider === "openai-compatible" && (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-openai-baseurl" className="text-xs">{t("openai.baseUrl")}</Label>
+              <Input
+                id="tts-openai-baseurl"
+                value={settings.openai.baseUrl}
+                onChange={(e) => update({ openai: { ...settings.openai, baseUrl: e.target.value } })}
+                placeholder="https://api.siliconflow.cn/v1"
+                className="h-8 text-xs font-mono"
+              />
+              <p className="text-[11px] text-[var(--text-muted)]">{t("openai.baseUrlHint")}</p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-openai-key" className="text-xs">{t("apiKey")}</Label>
+              <Input
+                id="tts-openai-key"
+                type="password"
+                autoComplete="new-password"
+                value={settings.openai.apiKey}
+                onChange={(e) => update({ openai: { ...settings.openai, apiKey: e.target.value } })}
+                className="h-8 text-xs"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-openai-model" className="text-xs">{t("openai.model")}</Label>
+              <Input
+                id="tts-openai-model"
+                value={settings.openai.model}
+                onChange={(e) => update({ openai: { ...settings.openai, model: e.target.value } })}
+                placeholder="gpt-4o-mini-tts / FunAudioLLM/CosyVoice2-0.5B"
+                className="h-8 text-xs font-mono"
+              />
+            </div>
+          </div>
+        )}
+
+        {provider === "volcengine" && (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-volc-appid" className="text-xs">{t("volcengine.appId")}</Label>
+              <Input
+                id="tts-volc-appid"
+                value={settings.volcengine.appId}
+                onChange={(e) => update({ volcengine: { ...settings.volcengine, appId: e.target.value } })}
+                className="h-8 text-xs font-mono"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-volc-token" className="text-xs">{t("volcengine.accessToken")}</Label>
+              <Input
+                id="tts-volc-token"
+                type="password"
+                autoComplete="new-password"
+                value={settings.volcengine.accessToken}
+                onChange={(e) => update({ volcengine: { ...settings.volcengine, accessToken: e.target.value } })}
+                className="h-8 text-xs"
+              />
+            </div>
+            <p className="text-[11px] text-[var(--text-muted)]">{t("volcengine.hint")}</p>
+          </div>
+        )}
+
+        {provider === "elevenlabs" && (
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-el-baseurl" className="text-xs">{t("elevenlabs.baseUrl")}</Label>
+              <Input
+                id="tts-el-baseurl"
+                value={settings.elevenlabs.baseUrl}
+                onChange={(e) => update({ elevenlabs: { ...settings.elevenlabs, baseUrl: e.target.value } })}
+                placeholder="https://api.elevenlabs.io"
+                className="h-8 text-xs font-mono"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-el-key" className="text-xs">{t("apiKey")}</Label>
+              <Input
+                id="tts-el-key"
+                type="password"
+                autoComplete="new-password"
+                value={settings.elevenlabs.apiKey}
+                onChange={(e) => update({ elevenlabs: { ...settings.elevenlabs, apiKey: e.target.value } })}
+                className="h-8 text-xs"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="tts-el-model" className="text-xs">{t("elevenlabs.model")}</Label>
+              <Input
+                id="tts-el-model"
+                value={settings.elevenlabs.model}
+                onChange={(e) => update({ elevenlabs: { ...settings.elevenlabs, model: e.target.value } })}
+                placeholder="eleven_multilingual_v2"
+                className="h-8 text-xs font-mono"
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleProbe}
+            disabled={probing || (provider !== "minimax" && !isCustomTtsActive(settings))}
+          >
+            {probing ? t("probing") : <>{<SpeakerHigh size={14} className="mr-1" />}{t("test")}</>}
+          </Button>
+          <Button type="button" size="sm" onClick={handleSave}>
+            {t("save")}
+          </Button>
+        </div>
+        <p className="text-[11px] text-[var(--text-muted)]">{t("testHint")}</p>
+      </section>
+
+      {/* 音色试听 */}
+      <section className="rounded-lg border border-[var(--border-color)] bg-[var(--bg-card)] p-4 space-y-3">
+        <div>
+          <h3 className="text-sm font-medium text-[var(--text-primary)]">{t("voices.title")}</h3>
+          <p className="text-xs text-[var(--text-muted)] mt-1">{t("voices.description")}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {presets.map((preset) => (
+            <Button
+              key={preset.id}
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={previewingVoice !== null || (provider !== "minimax" && !isCustomTtsActive(settings))}
+              onClick={() => handlePreview(preset.id)}
+              title={preset.id}
+              className="text-xs"
+            >
+              {previewingVoice === preset.id ? t("voices.loading") : <>{preset.name}<span className="ml-1 text-[10px] text-[var(--text-muted)]">{preset.gender === "male" ? t("voices.male") : t("voices.female")}</span></>}
+            </Button>
+          ))}
+        </div>
+        {provider !== "minimax" && !isCustomTtsActive(settings) && (
+          <p className="text-xs text-[var(--color-warning, #f59e0b)]">{t("voices.needConfig")}</p>
+        )}
+      </section>
+
+      {/* 当前状态 */}
+      <section className="rounded-lg border border-[var(--border-color)] bg-[var(--bg-card)] p-4">
+        <div className="flex items-center gap-2">
+          {provider === "minimax" || isCustomTtsActive(settings) ? (
+            <Check size={16} className="text-[var(--color-success)]" />
+          ) : (
+            <SpeakerHigh size={16} className="text-[var(--text-muted)]" />
+          )}
+          <p className="text-xs text-[var(--text-muted)]">
+            {provider === "minimax" || isCustomTtsActive(settings)
+              ? t("status.active", { provider: locale === "zh" ? TTS_PROVIDER_LABELS[provider].zh : TTS_PROVIDER_LABELS[provider].en })
+              : t("status.incomplete")}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/hooks/game-phases/useDayPhase.ts
+++ b/src/hooks/game-phases/useDayPhase.ts
@@ -17,7 +17,8 @@ import { getNextSpeechSeat } from "@/lib/speech-order";
 import { PHASE_CATEGORIES } from "@/lib/game-constants";
 import { type FlowToken } from "@/lib/game-flow-controller";
 import { audioManager, makeAudioTaskId } from "@/lib/audio-manager";
-import { resolveVoiceId, type AppLocale } from "@/lib/voice-constants";
+import { type AppLocale } from "@/lib/voice-constants";
+import { resolveVoiceIdForActiveProvider } from "@/lib/tts-client";
 import { getLocale } from "@/i18n/locale-store";
 import { isGameSessionExpiredMessage } from "@/lib/llm";
 
@@ -177,11 +178,12 @@ export function useDayPhase(
 
     // Get current locale for voice resolution
     const locale = getLocale() as AppLocale;
-    const voiceId = resolveVoiceId(
+    const voiceId = resolveVoiceIdForActiveProvider(
       player.agentProfile?.persona?.voiceId,
       player.agentProfile?.persona?.gender,
       player.agentProfile?.persona?.age,
-      locale
+      locale,
+      player.playerId,
     );
 
     const prefetchCriteria: PrefetchCriteria = {

--- a/src/hooks/useCredits.ts
+++ b/src/hooks/useCredits.ts
@@ -14,7 +14,9 @@ import {
   getZenmuxApiKey,
   getModelSource,
   setTokenPayConnected,
+  hasActiveCustomLlmKey,
 } from "@/lib/api-keys";
+import { buildCustomProviderHeaders } from "@/lib/custom-providers";
 import { clearGuestId, getGuestId, readGuestIdFromStorage } from "@/lib/demo-mode";
 import { supabase } from "@/lib/supabase";
 import {
@@ -168,7 +170,13 @@ export function useCredits() {
       const headerApiKey = customEnabled ? getZenmuxApiKey() : "";
       const dashscopeApiKey = customEnabled ? getDashscopeApiKey() : "";
       const tokendanceApiKey = customEnabled ? getTokendanceApiKey() : "";
-      const hasCustomKey = Boolean(headerApiKey || dashscopeApiKey || tokendanceApiKey);
+      const customProviderHeaders = customEnabled ? buildCustomProviderHeaders() : {};
+      const hasCustomKey = Boolean(
+        headerApiKey ||
+        dashscopeApiKey ||
+        tokendanceApiKey ||
+        hasActiveCustomLlmKey(),
+      );
       const tokenPayRequested = modelSource === "tokenpay";
       const tokendanceBaseUrl = customEnabled ? getTokendanceBaseUrl() : "";
       const requestInit: RequestInit = {
@@ -183,6 +191,7 @@ export function useCredits() {
           ...(tokendanceApiKey && tokendanceBaseUrl
             ? { "X-Tokendance-Base-Url": tokendanceBaseUrl }
             : {}),
+          ...customProviderHeaders,
           ...(tokenPayRequested ? { "X-TokenPay-Mode": "true" } : {}),
         },
         body: JSON.stringify({

--- a/src/hooks/useGameLogic.ts
+++ b/src/hooks/useGameLogic.ts
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 
 import { ALL_MODELS, PLAYER_MODELS, PROJECT_MODELS, isWolfRole, type GameState, type Player, type Phase, type Role, type DevPreset, type ModelRef, type StartGameOptions } from "@/types/game";
+import { getModelRefForCustomModel } from "@/lib/custom-providers";
 import { gameStateAtom, isValidTransition, clearPersistedGameState, isRestorableGameState } from "@/store/game-machine";
 import { getGeneratorModel, getModelSource } from "@/lib/api-keys";
 import {
@@ -64,6 +65,7 @@ function getModelRefForModel(model: string): ModelRef {
   return (
     PROJECT_MODELS.find((ref) => ref.model === model) ??
     ALL_MODELS.find((ref) => ref.model === model) ??
+    getModelRefForCustomModel(model) ??
     { provider: "zenmux" as const, model }
   );
 }

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -2322,5 +2322,92 @@
     "recharge": "Buy Game Credits",
     "startGame": "Continue Playing",
     "startGameNoCredits": "Buy Game Credits"
-  }
+  },
+
+    "customProviders": {
+      "short": "Custom",
+      "tab": "Custom Provider",
+      "title": "Custom OpenAI-compatible Provider",
+      "description": "Add any OpenAI-compatible endpoint with your own Base URL and API key (DeepSeek, Kimi, Zhipu, MiniMax, Grok, Gemini, Claude, OpenRouter, SiliconFlow, etc.). Test connectivity, then use its models in the model pool below.",
+      "activeBadge": "Active",
+      "modelCount": "{count} models",
+      "activate": "Set active",
+      "deactivate": "Deactivate",
+      "edit": "Edit",
+      "delete": "Delete",
+      "add": "Add provider",
+      "preset": "Vendor preset",
+      "presetPlaceholder": "Pick a vendor to fill the URL",
+      "name": "Name",
+      "namePlaceholder": "e.g. DeepSeek main",
+      "baseUrl": "Base URL",
+      "baseUrlHint": "OpenAI-compatible API root, usually ending with /v1; /v1 is appended for bare domains.",
+      "apiKey": "API Key",
+      "showKey": "Show key",
+      "hideKey": "Hide key",
+      "probe": "Test connection",
+      "probing": "Testing…",
+      "save": "Save",
+      "cancel": "Cancel",
+      "modelsPreview": "Fetched {count} models",
+      "toasts": {
+        "probeOkModels": "Connected, fetched {count} models",
+        "probeOkNoModels": "Connected (endpoint returned no model list, you can still save)",
+        "probeOkFallback": "Connected (endpoint lacks /models, verified with a minimal request)",
+        "probeFail": "Connection failed",
+        "missingFields": "Fill in Base URL and API Key first",
+        "saved": "Saved",
+        "deleted": "Deleted"
+      }
+    },
+    "ttsProvider": {
+      "tab": "Voice TTS",
+      "title": "TTS Voice Provider",
+      "description": "Choose the vendor that synthesizes AI voices. Uses the built-in MiniMax by default; switch to your own OpenAI-compatible, Volcengine, or ElevenLabs account.",
+      "provider": "Provider",
+      "apiKey": "API Key",
+      "test": "Test connection",
+      "probing": "Testing…",
+      "save": "Save",
+      "testHint": "The test synthesizes one short sentence with a default voice; nothing is played.",
+      "minimaxNote": "Uses the built-in MiniMax channel: server config in project mode, or the MiniMax key you saved under “Use my own key”.",
+      "openai": {
+        "baseUrl": "Base URL",
+        "baseUrlHint": "OpenAI /audio/speech compatible endpoint: OpenAI, SiliconFlow, Fish Audio, self-hosted gateways, etc.",
+        "model": "Model"
+      },
+      "stepfun": {
+        "baseUrl": "Base URL",
+        "baseUrlHint": "Standard API is https://api.stepfun.com/v1; Step Plan subscribers should use https://api.stepfun.com/step_plan/v1.",
+        "model": "Model"
+      },
+      "volcengine": {
+        "appId": "App ID",
+        "accessToken": "Access Token",
+        "hint": "Get these after enabling the speech service in the Volcengine console; voice IDs follow the console's activated list."
+      },
+      "elevenlabs": {
+        "baseUrl": "Base URL",
+        "model": "Model"
+      },
+      "voices": {
+        "title": "Voice preview",
+        "description": "Click a voice to preview. Characters get voices from the active provider's preset list based on gender and age.",
+        "loading": "Loading…",
+        "male": "M",
+        "female": "F",
+        "needConfig": "Fill in and save the credentials for this provider before previewing."
+      },
+      "status": {
+        "active": "Active: {provider}",
+        "incomplete": "Credentials incomplete — fill them in before saving."
+      },
+      "toasts": {
+        "saved": "Saved",
+        "probeOk": "Connected, voice is ready",
+        "probeFail": "Connection failed",
+        "previewFail": "Preview failed"
+      }
+    }
+  
 }

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -2404,5 +2404,92 @@
     "recharge": "充值游戏额度",
     "startGame": "继续开始游戏",
     "startGameNoCredits": "充值游戏额度"
-  }
+  },
+
+    "customProviders": {
+      "short": "自定义",
+      "tab": "自定义 Provider",
+      "title": "自定义 OpenAI 兼容 Provider",
+      "description": "填入任意 OpenAI 兼容端点的 Base URL 和 API Key（DeepSeek、Kimi、智谱、MiniMax、Grok、Gemini、Claude、OpenRouter、硅基流动等），测试连通后即可在下方模型池中选用其模型。",
+      "activeBadge": "使用中",
+      "modelCount": "{count} 个模型",
+      "activate": "设为使用中",
+      "deactivate": "取消使用",
+      "edit": "编辑",
+      "delete": "删除",
+      "add": "新增 Provider",
+      "preset": "厂商预设",
+      "presetPlaceholder": "选择厂商自动填入地址",
+      "name": "名称",
+      "namePlaceholder": "例如：DeepSeek 主力",
+      "baseUrl": "Base URL",
+      "baseUrlHint": "OpenAI 兼容根地址，通常以 /v1 结尾；只填域名时会自动补 /v1。",
+      "apiKey": "API Key",
+      "showKey": "显示 Key",
+      "hideKey": "隐藏 Key",
+      "probe": "测试连通",
+      "probing": "测试中…",
+      "save": "保存",
+      "cancel": "取消",
+      "modelsPreview": "拉取到 {count} 个模型",
+      "toasts": {
+        "probeOkModels": "连接成功，拉取到 {count} 个模型",
+        "probeOkNoModels": "连接成功（该端点未返回模型列表，可手动保存）",
+        "probeOkFallback": "连接成功（该端点不支持 /models，已用最小请求验证）",
+        "probeFail": "连接失败",
+        "missingFields": "请先填写 Base URL 和 API Key",
+        "saved": "已保存",
+        "deleted": "已删除"
+      }
+    },
+    "ttsProvider": {
+      "tab": "语音 TTS",
+      "title": "TTS 语音合成 Provider",
+      "description": "选择 AI 语音的合成厂商。默认使用内置 MiniMax；也可以换成你自己的 OpenAI 兼容、火山引擎或 ElevenLabs 账号。",
+      "provider": "厂商",
+      "apiKey": "API Key",
+      "test": "测试连通",
+      "probing": "测试中…",
+      "save": "保存",
+      "testHint": "测试会用默认音色合成一句话，不会播放声音。",
+      "minimaxNote": "使用内置 MiniMax 通道：项目模式走服务端配置；自定义模式下可使用你在「用我自己的 key 玩」里填写的 MiniMax Key。",
+      "openai": {
+        "baseUrl": "Base URL",
+        "baseUrlHint": "OpenAI /audio/speech 兼容端点，支持 OpenAI、硅基流动、Fish Audio、自部署网关等。",
+        "model": "模型"
+      },
+      "stepfun": {
+        "baseUrl": "Base URL",
+        "baseUrlHint": "标准 API 为 https://api.stepfun.com/v1；Step Plan 订阅用户请改用 https://api.stepfun.com/step_plan/v1。",
+        "model": "模型"
+      },
+      "volcengine": {
+        "appId": "App ID",
+        "accessToken": "Access Token",
+        "hint": "在火山引擎控制台开通语音合成服务后获取；音色 ID 以控制台的开通列表为准。"
+      },
+      "elevenlabs": {
+        "baseUrl": "Base URL",
+        "model": "模型"
+      },
+      "voices": {
+        "title": "音色试听",
+        "description": "点击音色名试听效果。角色创建时会按性别和年龄从当前厂商的音色表中分配。",
+        "loading": "生成中…",
+        "male": "男",
+        "female": "女",
+        "needConfig": "请先填写并保存当前厂商的凭据后再试听。"
+      },
+      "status": {
+        "active": "当前使用：{provider}",
+        "incomplete": "凭据未填完整，保存前请先补全。"
+      },
+      "toasts": {
+        "saved": "已保存",
+        "probeOk": "连接成功，语音可用",
+        "probeFail": "连接失败",
+        "previewFail": "试听失败"
+      }
+    }
+  
 }

--- a/src/lib/api-keys.ts
+++ b/src/lib/api-keys.ts
@@ -256,6 +256,19 @@ function resolveModelWhenCustomEnabled(preferred: string, fallbackPreferred: str
   return allowedPool[0].model;
 }
 
+function resolveCustomModelForRole(
+  storedValue: string,
+  fallbackValue: string,
+  storageKey: string
+): string {
+  // 自定义 Key 模式：存储值优先；为空时回退到 active custom Provider 的首个
+  // 模型（而不是内置 ZenMux——服务器没有内置 key，否则会 500）。
+  if (storedValue) return storedValue;
+  const customRefs = getCustomModelRefs();
+  if (customRefs.length > 0) return customRefs[0].model;
+  return fallbackValue;
+}
+
 function resolveModelForCurrentKeyState(
   storedValue: string,
   fallbackValue: string,

--- a/src/lib/api-keys.ts
+++ b/src/lib/api-keys.ts
@@ -5,6 +5,7 @@ import {
   SUMMARY_MODEL,
   REVIEW_MODEL,
 } from "@/types/game";
+import { getActiveCustomLlmProvider, getCustomModelRefs, getModelRefForCustomModel } from "@/lib/custom-providers";
 
 const ZENMUX_API_KEY_STORAGE = "wolfcha_zenmux_api_key";
 const DASHSCOPE_API_KEY_STORAGE = "wolfcha_dashscope_api_key";
@@ -167,7 +168,11 @@ export function hasMinimaxKey(): boolean {
 }
 
 function hasLocalLlmKey(): boolean {
-  return hasZenmuxKey() || hasDashscopeKey() || hasTokendanceKey();
+  return hasZenmuxKey() || hasDashscopeKey() || hasTokendanceKey() || hasActiveCustomLlmKey();
+}
+
+export function hasActiveCustomLlmKey(): boolean {
+  return getActiveCustomLlmProvider() !== null;
 }
 
 export function resolveModelSource(options: {
@@ -229,6 +234,12 @@ export function isTokenPayActive(): boolean {
 
 // When custom key is enabled, keep model within providers that have keys.
 function resolveModelWhenCustomEnabled(preferred: string, fallbackPreferred: string): string {
+  // 自定义 OpenAI 兼容 Provider 的模型不在内置 ALL_MODELS 里，
+  // 只要有启用的自定义 Provider 就原样放行。
+  if (!ALL_MODELS.some((ref) => ref.model === preferred) && getModelRefForCustomModel(preferred)) {
+    return preferred;
+  }
+
   const allowedProviders = new Set<(typeof ALL_MODELS)[number]["provider"]>();
   if (hasZenmuxKey()) allowedProviders.add("zenmux");
   if (hasDashscopeKey()) allowedProviders.add("dashscope");
@@ -299,7 +310,7 @@ export function getGeneratorModel(): string {
   if (source === "tokenpay") return AVAILABLE_MODELS[0]?.model ?? GENERATOR_MODEL;
   if (source !== "custom") return GENERATOR_MODEL;
   const stored = readStorage(GENERATOR_MODEL_STORAGE);
-  return resolveModelForCurrentKeyState(stored, GENERATOR_MODEL, GENERATOR_MODEL_STORAGE);
+  return resolveCustomModelForRole(stored, GENERATOR_MODEL, GENERATOR_MODEL_STORAGE);
 }
 
 export function setGeneratorModel(model: string) {
@@ -315,7 +326,7 @@ export function getSummaryModel(): string {
   if (source === "tokenpay") return AVAILABLE_MODELS[0]?.model ?? SUMMARY_MODEL;
   if (source !== "custom") return SUMMARY_MODEL;
   const stored = readStorage(SUMMARY_MODEL_STORAGE);
-  return resolveModelForCurrentKeyState(stored, SUMMARY_MODEL, SUMMARY_MODEL_STORAGE);
+  return resolveCustomModelForRole(stored, SUMMARY_MODEL, SUMMARY_MODEL_STORAGE);
 }
 
 export function setSummaryModel(model: string) {
@@ -331,7 +342,7 @@ export function getReviewModel(): string {
   if (source === "tokenpay") return AVAILABLE_MODELS[0]?.model ?? REVIEW_MODEL;
   if (source !== "custom") return REVIEW_MODEL;
   const stored = readStorage(REVIEW_MODEL_STORAGE);
-  return resolveModelForCurrentKeyState(stored, REVIEW_MODEL, REVIEW_MODEL_STORAGE);
+  return resolveCustomModelForRole(stored, REVIEW_MODEL, REVIEW_MODEL_STORAGE);
 }
 
 export function setReviewModel(model: string) {

--- a/src/lib/audio-manager.ts
+++ b/src/lib/audio-manager.ts
@@ -1,12 +1,11 @@
 import {
-  getMinimaxApiKey,
-  getMinimaxGroupId,
   getModelSource,
   hasMinimaxKey,
   resolveAiVoiceAvailability,
 } from "@/lib/api-keys";
 import { getAuthHeaders } from "@/lib/auth-headers";
 import { gameSessionTracker } from "@/lib/game-session-tracker";
+import { buildTtsRequestHeaders, getTtsSettings, isCustomTtsActive, type TtsProviderId } from "@/lib/tts-client";
 
 export interface AudioTask {
   id: string; // unique message id
@@ -16,7 +15,16 @@ export interface AudioTask {
 }
 
 export function makeAudioTaskId(voiceId: string, text: string) {
-  return `${voiceId}::${text}`;
+  // 缓存键带上 TTS Provider，切换 Provider 后不会误用旧音频
+  return `${getActiveTtsProviderId()}::${voiceId}::${text}`;
+}
+
+function getActiveTtsProviderId(): TtsProviderId {
+  try {
+    return getTtsSettings().provider;
+  } catch {
+    return "minimax";
+  }
 }
 
 type PlayState = "idle" | "playing" | "loading";
@@ -39,19 +47,15 @@ class AudioManager {
   }
 
   private async buildTtsHeaders(): Promise<Record<string, string>> {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    const modelSource = getModelSource();
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      ...buildTtsRequestHeaders(),
+    };
     const authHeaders = await getAuthHeaders();
     Object.assign(headers, authHeaders);
     const sessionId = gameSessionTracker.getSessionId();
     if (sessionId) {
       headers["X-Game-Session-Id"] = sessionId;
-    }
-    if (modelSource !== "project" && hasMinimaxKey()) {
-      const apiKey = getMinimaxApiKey();
-      const groupId = getMinimaxGroupId();
-      if (apiKey) headers["X-Minimax-Api-Key"] = apiKey;
-      if (groupId) headers["X-Minimax-Group-Id"] = groupId;
     }
     return headers;
   }
@@ -84,7 +88,10 @@ class AudioManager {
   }
 
   isEnabled(): boolean {
-    return this.enabled && resolveAiVoiceAvailability(getModelSource(), hasMinimaxKey());
+    if (!this.enabled) return false;
+    return (
+      resolveAiVoiceAvailability(getModelSource(), hasMinimaxKey()) || isCustomTtsActive()
+    );
   }
 
   /**

--- a/src/lib/character-generator.ts
+++ b/src/lib/character-generator.ts
@@ -15,6 +15,7 @@ import {
   type Persona,
   type PlayerMind,
 } from "@/types/game";
+import { getModelRefForCustomModel, getCustomModelRefs } from "@/lib/custom-providers";
 import {
   getGeneratorModel,
   getSelectedModels,
@@ -26,7 +27,9 @@ import {
 import { aiLogger } from "./ai-logger";
 import { GAME_TEMPERATURE } from "./ai-config";
 import { getRandomScenario } from "./scenarios";
-import { resolveVoiceId, VOICE_PRESETS, type AppLocale } from "./voice-constants";
+import { VOICE_PRESETS, type AppLocale } from "./voice-constants";
+import { resolveVoiceIdForActiveProvider } from "@/lib/tts-client";
+import { buildTemplateBaseProfiles } from "@/lib/template-profiles";
 import { getI18n } from "@/i18n/translator";
 import { parseLLMJson } from "./llm-json";
 
@@ -71,6 +74,7 @@ function getModelRefForModel(model: string): ModelRef {
   return (
     PROJECT_MODELS.find((ref) => ref.model === model) ??
     ALL_MODELS.find((ref) => ref.model === model) ??
+    getModelRefForCustomModel(model) ??
     { provider: "zenmux" as const, model }
   );
 }
@@ -85,13 +89,20 @@ export const sampleModelRefs = (count: number): ModelRef[] => {
   const pool = (() => {
     if (!isCustomKeyEnabled()) return defaultPool;
 
-    // When custom key is enabled, use ALL_MODELS as the full available pool
-    const fullPool = ALL_MODELS.length > 0 ? ALL_MODELS : defaultPool;
+    // When custom key is enabled, use ALL_MODELS (plus any active custom
+    // OpenAI-compatible provider's models) as the full available pool
+    const customModelRefs = getCustomModelRefs();
+    const fullPool = customModelRefs.length > 0
+      ? [...ALL_MODELS, ...customModelRefs]
+      : ALL_MODELS.length > 0
+        ? ALL_MODELS
+        : defaultPool;
 
     const allowedProviders = new Set<ModelRef["provider"]>();
     if (hasZenmuxKey()) allowedProviders.add("zenmux");
     if (hasDashscopeKey()) allowedProviders.add("dashscope");
     if (hasTokendanceKey()) allowedProviders.add("tokendance");
+    if (customModelRefs.length > 0) allowedProviders.add("custom");
     if (allowedProviders.size === 0) return defaultPool;
 
     // Filter by allowed providers, then exclude non-player models
@@ -556,17 +567,11 @@ export async function generateCharacters(
 ): Promise<GeneratedCharacter[]> {
   const usedScenario = scenario ?? getRandomScenario();
   const basePrompt = buildBaseProfilesPrompt(count, usedScenario);
-  const baseResult = await generateJSON<unknown>({
-    model: getGeneratorModel(),
-    messages: [{ role: "user", content: basePrompt }],
-    temperature: GAME_TEMPERATURE.CHARACTER_GENERATION,
-    max_tokens: Math.max(2400, count * 350 + 600),
-    reasoning: CHARACTER_GENERATOR_REASONING,
-    response_format: buildBaseProfilesResponseFormat(count),
-  });
-  const baseProfiles = normalizeBaseProfiles(baseResult).profiles;
+  // 基础档案使用本地模板库确定性生成（零 LLM 调用），把角色进场速度从
+  // "先生成档案再生成形象"的两阶段压到"一人一流式并发"的一阶段。
+  const baseProfiles = buildTemplateBaseProfiles(count, usedScenario);
   if (!isValidBaseProfiles(baseProfiles, count)) {
-    throw new Error("Base profile generation returned invalid schema");
+    throw new Error("Base profile template generation failed");
   }
   options?.onBaseProfiles?.(baseProfiles);
 
@@ -629,11 +634,12 @@ export async function generateCharacters(
             continue;
           }
 
-          const voiceId = resolveVoiceId(
+          const voiceId = resolveVoiceIdForActiveProvider(
             normalized.persona.voiceId,
             normalized.persona.gender,
             normalized.persona.age,
             "zh" as AppLocale,
+            profile.displayName,
           );
           const character: GeneratedCharacter = {
             displayName: profile.displayName,
@@ -665,11 +671,12 @@ export async function generateCharacters(
         aligned.forEach((character, localIndex) => {
           if (batchCharacters[localIndex]) return;
           const profile = batchProfiles[localIndex];
-          const voiceId = resolveVoiceId(
+          const voiceId = resolveVoiceIdForActiveProvider(
             character.persona.voiceId,
             character.persona.gender,
             character.persona.age,
             "zh" as AppLocale,
+            profile.displayName,
           );
           const completed: GeneratedCharacter = {
             displayName: profile.displayName,

--- a/src/lib/custom-providers.test.ts
+++ b/src/lib/custom-providers.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+// 纯函数导入（不触发 localStorage 访问路径）
+import {
+  joinProviderUrl,
+  normalizeBaseUrl,
+} from "./custom-providers";
+
+test("joinProviderUrl 保留调用方给的完整 API 根路径", () => {
+  assert.equal(
+    joinProviderUrl("https://api.deepseek.com/v1", "chat/completions"),
+    "https://api.deepseek.com/v1/chat/completions",
+  );
+  assert.equal(
+    joinProviderUrl("https://open.bigmodel.cn/api/paas/v4", "chat/completions"),
+    "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+  );
+});
+
+test("joinProviderUrl 对裸域名自动补 /v1", () => {
+  assert.equal(
+    joinProviderUrl("https://api.example.com", "chat/completions"),
+    "https://api.example.com/v1/chat/completions",
+  );
+  assert.equal(
+    joinProviderUrl("https://api.example.com/", "models"),
+    "https://api.example.com/v1/models",
+  );
+});
+
+test("joinProviderUrl 去掉末尾斜杠且不重复拼接路径分隔符", () => {
+  assert.equal(
+    joinProviderUrl("https://api.example.com/v1/", "audio/speech"),
+    "https://api.example.com/v1/audio/speech",
+  );
+});
+
+test("joinProviderUrl 拒绝空地址和非 http(s) 协议", () => {
+  assert.equal(joinProviderUrl("", "chat/completions"), null);
+  assert.equal(joinProviderUrl("   ", "chat/completions"), null);
+  assert.equal(joinProviderUrl("ftp://files.example.com", "chat/completions"), null);
+  assert.equal(joinProviderUrl("not a url", "chat/completions"), null);
+});
+
+test("normalizeBaseUrl 去除首尾空白与末尾斜杠", () => {
+  assert.equal(normalizeBaseUrl("  https://api.example.com/v1/  "), "https://api.example.com/v1");
+  assert.equal(normalizeBaseUrl("https://api.example.com"), "https://api.example.com");
+});

--- a/src/lib/custom-providers.ts
+++ b/src/lib/custom-providers.ts
@@ -1,0 +1,260 @@
+import type { ModelRef } from "@/types/game";
+
+/**
+ * 自定义 OpenAI 兼容 LLM Provider（用户自带 key + base URL）。
+ *
+ * 与内置的 zenmux/dashscope/tokendance 三家不同，自定义 Provider 不依赖
+ * 服务器环境变量：配置存放在浏览器 localStorage，请求时通过
+ * `X-Custom-Base-Url` / `X-Custom-Api-Key` 头透传给 `/api/chat` 代理转发。
+ * 所有主流厂商（DeepSeek、Kimi、智谱、MiniMax、xAI、Gemini、Claude、
+ * OpenRouter、硅基流动等）都提供 OpenAI 兼容端点，共用一条转发通道。
+ */
+
+export interface CustomLlmProvider {
+  id: string;
+  name: string;
+  /** OpenAI 兼容 API 根地址，例如 https://api.deepseek.com/v1 */
+  baseUrl: string;
+  apiKey: string;
+  /** 通过 /models 拉取并缓存的可用模型 ID 列表 */
+  modelIds: string[];
+}
+
+export interface LlmProviderPreset {
+  key: string;
+  name: string;
+  baseUrl: string;
+  /** 预设可能依赖厂商侧的兼容层，UI 上提示用户先测连通 */
+  note?: "compat";
+}
+
+export const LLM_PROVIDER_PRESETS: LlmProviderPreset[] = [
+  { key: "deepseek", name: "DeepSeek", baseUrl: "https://api.deepseek.com/v1" },
+  { key: "moonshot", name: "Kimi (Moonshot)", baseUrl: "https://api.moonshot.cn/v1" },
+  { key: "zhipu", name: "智谱 GLM", baseUrl: "https://open.bigmodel.cn/api/paas/v4" },
+  { key: "minimax", name: "MiniMax", baseUrl: "https://api.minimaxi.com/v1" },
+  { key: "stepfun", name: "阶跃星辰 StepFun", baseUrl: "https://api.stepfun.com/v1" },
+  { key: "xai", name: "Grok (xAI)", baseUrl: "https://api.x.ai/v1" },
+  { key: "gemini", name: "Gemini (OpenAI 兼容层)", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", note: "compat" },
+  { key: "anthropic", name: "Claude (OpenAI 兼容层)", baseUrl: "https://api.anthropic.com/v1", note: "compat" },
+  { key: "openrouter", name: "OpenRouter", baseUrl: "https://openrouter.ai/api/v1" },
+  { key: "siliconflow", name: "硅基流动 SiliconFlow", baseUrl: "https://api.siliconflow.cn/v1" },
+  { key: "custom", name: "自定义", baseUrl: "" },
+];
+
+const PROVIDERS_STORAGE = "wolfcha_custom_llm_providers";
+const ACTIVE_PROVIDER_STORAGE = "wolfcha_custom_llm_active";
+
+export const CUSTOM_PROVIDER_BASE_URL_HEADER = "X-Custom-Base-Url";
+export const CUSTOM_PROVIDER_API_KEY_HEADER = "X-Custom-Api-Key";
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function readProviders(): CustomLlmProvider[] {
+  if (!canUseStorage()) return [];
+  const raw = window.localStorage.getItem(PROVIDERS_STORAGE);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((item): item is Record<string, unknown> =>
+        typeof item === "object" && item !== null)
+      .map((item) => ({
+        id: String(item.id ?? ""),
+        name: String(item.name ?? "").trim() || "Custom Provider",
+        baseUrl: String(item.baseUrl ?? "").trim(),
+        apiKey: String(item.apiKey ?? "").trim(),
+        modelIds: Array.isArray(item.modelIds)
+          ? item.modelIds.map((m) => String(m ?? "").trim()).filter(Boolean).slice(0, 500)
+          : [],
+      }))
+      .filter((p) => p.id && p.baseUrl);
+  } catch {
+    return [];
+  }
+}
+
+function writeProviders(providers: CustomLlmProvider[]) {
+  if (!canUseStorage()) return;
+  window.localStorage.setItem(PROVIDERS_STORAGE, JSON.stringify(providers));
+}
+
+export function listCustomLlmProviders(): CustomLlmProvider[] {
+  return readProviders();
+}
+
+export function getCustomLlmProvider(id: string): CustomLlmProvider | null {
+  return readProviders().find((p) => p.id === id) ?? null;
+}
+
+export function saveCustomLlmProvider(provider: CustomLlmProvider): CustomLlmProvider[] {
+  const providers = readProviders();
+  const normalized: CustomLlmProvider = {
+    ...provider,
+    id: provider.id || generateProviderId(),
+    name: provider.name.trim() || "Custom Provider",
+    baseUrl: normalizeBaseUrl(provider.baseUrl),
+    apiKey: provider.apiKey.trim(),
+    modelIds: provider.modelIds.filter(Boolean).slice(0, 500),
+  };
+  const index = providers.findIndex((p) => p.id === normalized.id);
+  if (index >= 0) providers[index] = normalized;
+  else providers.push(normalized);
+  writeProviders(providers);
+  return providers;
+}
+
+export function deleteCustomLlmProvider(id: string): CustomLlmProvider[] {
+  const providers = readProviders().filter((p) => p.id !== id);
+  writeProviders(providers);
+  if (getActiveCustomLlmProviderId() === id) {
+    setActiveCustomLlmProviderId(null);
+  }
+  return providers;
+}
+
+export function generateProviderId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `cp_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function getActiveCustomLlmProviderId(): string | null {
+  if (!canUseStorage()) return null;
+  return window.localStorage.getItem(ACTIVE_PROVIDER_STORAGE) || null;
+}
+
+export function setActiveCustomLlmProviderId(id: string | null) {
+  if (!canUseStorage()) return;
+  if (id) window.localStorage.setItem(ACTIVE_PROVIDER_STORAGE, id);
+  else window.localStorage.removeItem(ACTIVE_PROVIDER_STORAGE);
+}
+
+/** 当前启用中的自定义 Provider；要求已填 apiKey 才视为可用。 */
+export function getActiveCustomLlmProvider(): CustomLlmProvider | null {
+  const activeId = getActiveCustomLlmProviderId();
+  if (!activeId) return null;
+  const provider = getCustomLlmProvider(activeId);
+  return provider && provider.apiKey && provider.baseUrl ? provider : null;
+}
+
+/**
+ * 拼接 OpenAI 兼容端点 URL。约定 baseUrl 是 API 根（通常以 /v1 或厂商
+ * 等价路径结尾）；只有裸域名时才自动补 /v1。
+ */
+export function joinProviderUrl(baseUrl: string, path: string): string | null {
+  const trimmed = baseUrl.trim().replace(/\/+$/, "");
+  if (!trimmed) return null;
+  let origin: string;
+  let suffix: string;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    const pathPart = url.pathname.replace(/\/+$/, "");
+    origin = `${url.protocol}//${url.host}`;
+    suffix = pathPart || "/v1";
+  } catch {
+    return null;
+  }
+  return `${origin}${suffix}/${path.replace(/^\/+/, "")}`;
+}
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
+/** 自定义 Provider 下的可用模型列表（供模型池采样）。 */
+export function getCustomModelRefs(): ModelRef[] {
+  const provider = getActiveCustomLlmProvider();
+  if (!provider) return [];
+  return provider.modelIds.map((model) => ({ provider: "custom" as const, model }));
+}
+
+export function isCustomModel(model: string): boolean {
+  return getCustomModelRefs().some((ref) => ref.model === model);
+}
+
+/** 三处 getModelRefForModel 兜底共用：自定义模型 → custom ModelRef。 */
+export function getModelRefForCustomModel(model: string): ModelRef | null {
+  return getCustomModelRefs().find((ref) => ref.model === model) ?? null;
+}
+
+/** 组装透传给 /api/chat 的请求头；无可用自定义 Provider 时返回空对象。 */
+export function buildCustomProviderHeaders(): Record<string, string> {
+  const provider = getActiveCustomLlmProvider();
+  if (!provider) return {};
+  return {
+    [CUSTOM_PROVIDER_BASE_URL_HEADER]: provider.baseUrl,
+    [CUSTOM_PROVIDER_API_KEY_HEADER]: provider.apiKey,
+  };
+}
+
+export interface CustomProviderProbeResult {
+  ok: boolean;
+  models?: string[];
+  error?: string;
+  /** /models 不可用（部分网关不实现）时用最小对话请求兜底验证 */
+  fellBackToChatProbe?: boolean;
+}
+
+/**
+ * 连通性测试：走服务端 `/api/llm-models` 代理（浏览器直连各厂商会被
+ * CORS 拦截）。服务端优先 GET /models（零 token 消耗），失败时退回一条
+ * max_tokens=1 的最小对话请求。
+ */
+export async function probeCustomLlmProvider(
+  input: { baseUrl: string; apiKey: string; model?: string },
+): Promise<CustomProviderProbeResult> {
+  const baseUrl = normalizeBaseUrl(input.baseUrl);
+  const apiKey = input.apiKey.trim();
+  if (!baseUrl || !apiKey) {
+    return { ok: false, error: "请先填写 Base URL 和 API Key" };
+  }
+
+  try {
+    const { getAuthHeaders } = await import("@/lib/auth-headers");
+    const response = await fetch("/api/llm-models", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...buildProbeHeaders(baseUrl, apiKey, input.model),
+        ...(await getAuthHeaders()),
+      },
+      cache: "no-store",
+    });
+    const data: unknown = await response.json().catch(() => null);
+    if (response.ok && typeof data === "object" && data !== null && (data as { ok?: unknown }).ok === true) {
+      const record = data as { models?: unknown; fellBackToChatProbe?: unknown };
+      return {
+        ok: true,
+        models: Array.isArray(record.models) ? record.models.map((m) => String(m)) : [],
+        fellBackToChatProbe: record.fellBackToChatProbe === true,
+      };
+    }
+    const message =
+      typeof data === "object" && data !== null && typeof (data as { error?: unknown }).error === "string"
+        ? (data as { error: string }).error
+        : `验证失败（HTTP ${response.status}）`;
+    return { ok: false, error: message };
+  } catch (error) {
+    return { ok: false, error: `连接失败: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+export function buildProbeHeaders(baseUrl: string, apiKey: string, model?: string): Record<string, string> {
+  return {
+    [CUSTOM_PROVIDER_BASE_URL_HEADER]: normalizeBaseUrl(baseUrl),
+    [CUSTOM_PROVIDER_API_KEY_HEADER]: apiKey.trim(),
+    ...(model?.trim() ? { "X-Custom-Model": model.trim() } : {}),
+  };
+}
+
+export function clearCustomLlmProviders() {
+  if (!canUseStorage()) return;
+  window.localStorage.removeItem(PROVIDERS_STORAGE);
+  window.localStorage.removeItem(ACTIVE_PROVIDER_STORAGE);
+}

--- a/src/lib/game-master.ts
+++ b/src/lib/game-master.ts
@@ -16,6 +16,7 @@ import {
   PROJECT_MODELS,
   type ModelRef,
 } from "@/types/game";
+import { getModelRefForCustomModel } from "@/lib/custom-providers";
 import { GAME_TEMPERATURE } from "./ai-config";
 import { sampleModelRefs, type GeneratedCharacter } from "./character-generator";
 import { aiLogger } from "./ai-logger";
@@ -68,6 +69,7 @@ function getModelRefForModel(model: string): ModelRef {
   return (
     PROJECT_MODELS.find((ref) => ref.model === model) ??
     ALL_MODELS.find((ref) => ref.model === model) ??
+    getModelRefForCustomModel(model) ??
     { provider: "zenmux" as const, model }
   );
 }

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -8,7 +8,8 @@ import {
   setTokenPayConnected,
   type ModelSource,
 } from "@/lib/api-keys";
-import { ALL_MODELS, AVAILABLE_MODELS, PROJECT_MODELS, type ModelRef } from "@/types/game";
+import { buildCustomProviderHeaders, getModelRefForCustomModel } from "@/lib/custom-providers";
+import { ALL_MODELS, AVAILABLE_MODELS, PROJECT_MODELS, type ModelRef, type LlmProviderId } from "@/types/game";
 import { gameStatsTracker } from "@/hooks/useGameStats";
 import { gameSessionTracker } from "@/lib/game-session-tracker";
 import { getAuthHeaders } from "@/lib/auth-headers";
@@ -36,7 +37,7 @@ export interface LLMMessage {
   reasoning_details?: unknown;
 }
 
-type Provider = "zenmux" | "dashscope" | "tokendance";
+type Provider = LlmProviderId;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -46,7 +47,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function getProviderForModel(model: string): Provider {
   const modelRef =
     ALL_MODELS.find((ref) => ref.model === model) ??
-    PROJECT_MODELS.find((ref) => ref.model === model);
+    PROJECT_MODELS.find((ref) => ref.model === model) ??
+    getModelRefForCustomModel(model);
   return modelRef?.provider ?? "zenmux";
 }
 
@@ -114,6 +116,7 @@ function buildModelSourceHeaders(source: ModelSource): Record<string, string> {
     ...(tokendanceApiKey && tokendanceBaseUrl
       ? { "X-Tokendance-Base-Url": tokendanceBaseUrl }
       : {}),
+    ...buildCustomProviderHeaders(),
   };
 }
 

--- a/src/lib/server-game-observability.ts
+++ b/src/lib/server-game-observability.ts
@@ -1,3 +1,4 @@
+import type { LlmProviderId } from "@/types/game";
 import "server-only";
 
 import { withTimeout } from "@/lib/request-timeout";
@@ -36,7 +37,7 @@ export interface GameSessionAiAttemptInput {
   userId: string;
   requestId: string;
   attempt: number;
-  provider: "zenmux" | "dashscope" | "tokendance";
+  provider: LlmProviderId;
   promptScope: "gameplay" | "utility";
   mode: "completion" | "batch" | "stream";
   outcome: GameSessionAiOutcome;
@@ -128,8 +129,9 @@ async function writeGameSessionAiAttempt(
     p_model: input.model,
     p_input_chars: input.inputChars,
     p_output_chars: input.outputChars,
-    p_prompt_tokens: input.promptTokens,
-    p_completion_tokens: input.completionTokens,
+    // 自定义 OpenAI 兼容 Provider 的流式响应常无 usage 统计；RPC 校验拒绝 NULL，归零兜底
+    p_prompt_tokens: input.promptTokens ?? 0,
+    p_completion_tokens: input.completionTokens ?? 0,
   });
 
   const result = data?.[0];

--- a/src/lib/template-profiles.ts
+++ b/src/lib/template-profiles.ts
@@ -1,0 +1,78 @@
+import type { GameScenario } from "@/types/game";
+
+/**
+ * 角色基础档案本地模板库。
+ *
+ * 进场提速的关键：基础档案（姓名/性别/年龄/MBTI/一句话背景）由本地模板
+ * 确定性生成，不再消耗一次 LLM 生成调用。模板从各场景 rolesHint 演化而来，
+ * 数量足够覆盖 6-12 人，且保证姓名唯一。
+ */
+
+export interface BaseProfile {
+  displayName: string;
+  gender: "male" | "female" | "nonbinary";
+  age: number;
+  mbti: string;
+  basicInfo: string;
+}
+
+interface TemplatePerson {
+  name: string;
+  gender: "male" | "female" | "nonbinary";
+  age: number;
+  mbti: string;
+  info: string;
+}
+
+const NB: "nonbinary" = "nonbinary";
+
+const COMMON_TEMPLATES: TemplatePerson[] = [
+  { name: "张建国", gender: "male", age: 55, mbti: "ISTJ", info: "在小区的退休老干部，爱组织棋牌室活动" },
+  { name: "刘芳", gender: "female", age: 48, mbti: "ISFJ", info: "退休的幼儿园老师，细心体贴" },
+  { name: "李梅", gender: "female", age: 35, mbti: "ENFP", info: "带娃的宝妈，全职在家照顾家庭" },
+  { name: "王磊", gender: "male", age: 35, mbti: "ISTP", info: "物业公司经理，八面玲珑但话不多" },
+  { name: "陈悦", gender: "female", age: 26, mbti: "INFJ", info: "街道办工作的年轻女孩" },
+  { name: "吴哥", gender: "male", age: 42, mbti: "ESTJ", info: "小区门口水果店老板，嗓门大热心肠" },
+  { name: "周婷", gender: "female", age: 31, mbti: "ESFP", info: "专打物业纠纷的律师，能说会道" },
+  { name: "赵阳", gender: "male", age: 22, mbti: "ENTP", info: "互联网公司运营，刚毕业两年" },
+  { name: "孙丽", gender: "female", age: 29, mbti: "ENTJ", info: "社区来来往往的接待委员，爱张罗" },
+  { name: "何军", gender: "male", age: 47, mbti: "ISFP", info: "小区保安队长，踏实寡言" },
+  { name: "郑晓", gender: "female", age: 24, mbti: "INFP", info: "刚毕业的职场新人，敏感但善良" },
+  { name: "钱峰", gender: "male", age: 33, mbti: "INTJ", info: "电商公司的运营专员，逻辑性强" },
+];
+
+const SCENARIO_ROLE_HINTS: Record<string, string[]> = {
+  high_school_reunion: ["班级里爱出风头的", "当年低调的学霸", "混得风生水起的生意人", "一直单身的老实人", "早早就结婚的班花"],
+  family_dinner: ["爱说话的亲戚", "饭桌上不喝酒的长辈", "总催婚的姑姑", "默默干活的小辈", "话不多但毒舌的舅妈"],
+  wedding_banquet: ["新人的发小", "双方都认识的伴郎", "爱张罗的婚礼主家", "来凑热闹的表亲"],
+  community_committee: ["热心业主代表", "物业经理", "爱录音的老大爷", "带娃的宝妈", "刚搬来的新业主"],
+  tech_startup: ["创业公司 CEO", "技术总监", "运维工程师", "产品经理", "市场部负责人"],
+};
+
+function hashString(str: string): number {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+/** 确定性生成 count 个基础档案（性别、年龄、MBTI 交错分布），姓名保证唯一。 */
+export function buildTemplateBaseProfiles(count: number, scenario?: GameScenario): BaseProfile[] {
+  const templates = [...COMMON_TEMPLATES];
+  // 用场景 id 做哈希选取偏移，保证不同场景随机但同场景可复现
+  const seed = hashString(scenario?.id ?? "default");
+  const ordered = [...templates];
+  for (let i = ordered.length - 1; i > 0; i--) {
+    const j = hashString(`${seed}:${i}`) % (i + 1);
+    [ordered[i], ordered[j]] = [ordered[j], ordered[i]];
+  }
+  const picked = ordered.slice(0, count);
+  return picked.map((p, i) => ({
+    displayName: p.name,
+    gender: p.gender,
+    age: p.age,
+    mbti: p.mbti,
+    basicInfo: `${p.info}，${SCENARIO_ROLE_HINTS[scenario?.id ?? ""]?.[i % 5] ?? "普通住家居民"}`,
+  }));
+}

--- a/src/lib/tts-client.test.ts
+++ b/src/lib/tts-client.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  getTtsSettings,
+  saveTtsSettings,
+  isCustomTtsActive,
+  resolveVoiceIdForActiveProvider,
+} from "./tts-client";
+
+/**
+ * tts-client 在 Node 测试环境没有 window，需要先注入 localStorage 桩，
+ * 才能 exercise 配置读取路径（函数体惰性读取，静态导入安全）。
+ */
+interface StorageStub {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+}
+
+function installWindowStorage(storage: Record<string, string>) {
+  const stub: StorageStub = {
+    getItem: (key) => (key in storage ? storage[key] : null),
+    setItem: (key, value) => {
+      storage[key] = value;
+    },
+    removeItem: (key) => {
+      delete storage[key];
+    },
+  };
+  (globalThis as unknown as { window: { localStorage: StorageStub; dispatchEvent: () => boolean } }).window = {
+    localStorage: stub,
+    dispatchEvent: () => true,
+  };
+  return storage as Record<string, string>;
+}
+
+const storage = installWindowStorage({});
+
+test("默认 TTS 配置是内置 MiniMax，且不算自定义 TTS", () => {
+  delete storage["wolfcha_tts_settings_v1"];
+  const settings = getTtsSettings();
+  assert.equal(settings.provider, "minimax");
+  assert.equal(isCustomTtsActive(settings), false);
+});
+
+test("保存 OpenAI 兼容配置后自定义 TTS 生效", () => {
+  delete storage["wolfcha_tts_settings_v1"];
+  const settings = saveTtsSettings({
+    ...getTtsSettings(),
+    provider: "openai-compatible",
+    openai: { baseUrl: "https://api.siliconflow.cn/v1", apiKey: "sk-test", model: "FunAudioLLM/CosyVoice2-0.5B" },
+  });
+  assert.equal(isCustomTtsActive(settings), true);
+  assert.equal(getTtsSettings().provider, "openai-compatible");
+});
+
+test("火山引擎缺少任一凭据时不算可用", () => {
+  const base = getTtsSettings();
+  const missingToken = {
+    ...base,
+    provider: "volcengine" as const,
+    volcengine: { appId: "app-1", accessToken: "" },
+  };
+  assert.equal(isCustomTtsActive(missingToken), false);
+  const complete = {
+    ...base,
+    provider: "volcengine" as const,
+    volcengine: { appId: "app-1", accessToken: "token-1" },
+  };
+  assert.equal(isCustomTtsActive(complete), true);
+});
+
+test("MiniMax Provider 下合法音色 ID 原样保留（与旧 resolveVoiceId 行为一致）", () => {
+  delete storage["wolfcha_tts_settings_v1"];
+  const voiceId = resolveVoiceIdForActiveProvider(
+    "male-qn-jingying",
+    "male",
+    30,
+    "zh",
+  );
+  assert.equal(voiceId, "male-qn-jingying");
+});
+
+test("非 MiniMax Provider 会把旧存档的异 Provider 音色稳定映射到新音色表", () => {
+  saveTtsSettings({
+    ...getTtsSettings(),
+    provider: "openai-compatible",
+    openai: { baseUrl: "https://api.example.com/v1", apiKey: "sk-test", model: "gpt-4o-mini-tts" },
+  });
+
+  const a1 = resolveVoiceIdForActiveProvider("male-qn-jingying", "male", 30, "zh", "player-1");
+  const a2 = resolveVoiceIdForActiveProvider("male-qn-jingying", "male", 30, "zh", "player-1");
+  const b = resolveVoiceIdForActiveProvider("male-qn-jingying", "male", 30, "zh", "player-2");
+
+  // 同一种子确定性收敛，不同种子应能产生区分
+  assert.equal(a1, a2);
+  assert.notEqual(a1, b);
+
+  // 命中当前 Provider 音色表的输入直接保留
+  assert.equal(resolveVoiceIdForActiveProvider("alloy", "female", 30, "zh", "x"), "alloy");
+});

--- a/src/lib/tts-client.ts
+++ b/src/lib/tts-client.ts
@@ -1,0 +1,311 @@
+import { getMinimaxApiKey, getMinimaxGroupId, getModelSource, hasMinimaxKey } from "@/lib/api-keys";
+import { STEPFUN_ENGLISH_VOICE_PRESETS, STEPFUN_VOICE_PRESETS } from "@/lib/tts/stepfun-voices";
+import type { TtsCredentials, TtsProviderId } from "@/lib/tts/types";
+import {
+  DEFAULT_VOICE_ID,
+  DEFAULT_VOICE_ID_EN,
+  ENGLISH_VOICE_PRESETS,
+  VOICE_PRESETS,
+  type AppLocale,
+  type VoicePreset,
+} from "@/lib/voice-constants";
+
+/**
+ * TTS Provider 的前端配置层（localStorage）。
+ *
+ * - `minimax`：保持旧行为——服务端 env（项目模式）或用户在旧入口填的
+ *   MiniMax key（自定义模式）。
+ * - 其他 Provider：用户自带的凭据，通过 `x-tts-*` 请求头透传给 `/api/tts`。
+ */
+
+export type { TtsProviderId };
+
+export interface TtsSettings {
+  provider: TtsProviderId;
+  openai: { baseUrl: string; apiKey: string; model: string };
+  stepfun: { baseUrl: string; apiKey: string; model: string };
+  volcengine: { appId: string; accessToken: string };
+  elevenlabs: { baseUrl: string; apiKey: string; model: string };
+}
+
+const STORAGE_KEY = "wolfcha_tts_settings_v1";
+export const TTS_SETTINGS_CHANGE_EVENT = "wolfcha:tts-settings-change";
+
+export const TTS_PROVIDER_LABELS: Record<TtsProviderId, { zh: string; en: string }> = {
+  minimax: { zh: "MiniMax（内置）", en: "MiniMax (built-in)" },
+  stepfun: { zh: "阶跃星辰 StepFun", en: "StepFun" },
+  "openai-compatible": { zh: "OpenAI 兼容（OpenAI / 硅基流动 / Fish Audio…）", en: "OpenAI-compatible (OpenAI / SiliconFlow / Fish Audio…)" },
+  volcengine: { zh: "火山引擎（豆包）", en: "Volcengine (Doubao)" },
+  elevenlabs: { zh: "ElevenLabs", en: "ElevenLabs" },
+};
+
+const DEFAULT_SETTINGS: TtsSettings = {
+  provider: "minimax",
+  openai: { baseUrl: "https://api.openai.com/v1", apiKey: "", model: "gpt-4o-mini-tts" },
+  stepfun: { baseUrl: "https://api.stepfun.com/v1", apiKey: "", model: "step-tts-mini" },
+  volcengine: { appId: "", accessToken: "" },
+  elevenlabs: { baseUrl: "https://api.elevenlabs.io", apiKey: "", model: "eleven_multilingual_v2" },
+};
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function getTtsSettings(): TtsSettings {
+  if (!canUseStorage()) return { ...DEFAULT_SETTINGS };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT_SETTINGS };
+    const parsed = JSON.parse(raw) as Partial<TtsSettings>;
+    return {
+      provider: isProviderId(parsed.provider) ? parsed.provider : "minimax",
+      openai: { ...DEFAULT_SETTINGS.openai, ...parsed.openai },
+      stepfun: { ...DEFAULT_SETTINGS.stepfun, ...parsed.stepfun },
+      volcengine: { ...DEFAULT_SETTINGS.volcengine, ...parsed.volcengine },
+      elevenlabs: { ...DEFAULT_SETTINGS.elevenlabs, ...parsed.elevenlabs },
+    };
+  } catch {
+    return { ...DEFAULT_SETTINGS };
+  }
+}
+
+export function saveTtsSettings(settings: TtsSettings): TtsSettings {
+  if (!canUseStorage()) return settings;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  window.dispatchEvent(new CustomEvent(TTS_SETTINGS_CHANGE_EVENT, { detail: settings.provider }));
+  return settings;
+}
+
+function isProviderId(value: unknown): value is TtsProviderId {
+  return (
+    value === "minimax" ||
+    value === "openai-compatible" ||
+    value === "stepfun" ||
+    value === "volcengine" ||
+    value === "elevenlabs"
+  );
+}
+
+/** 当前 Provider 是否已填好自备凭据（minimax 始终视为可用，走 env/旧配置）。 */
+export function isCustomTtsActive(settings?: TtsSettings): boolean {
+  const s = settings ?? getTtsSettings();
+  if (s.provider === "minimax") return false;
+  if (s.provider === "openai-compatible") return Boolean(s.openai.apiKey.trim());
+  if (s.provider === "stepfun") return Boolean(s.stepfun.apiKey.trim());
+  if (s.provider === "volcengine") return Boolean(s.volcengine.appId.trim() && s.volcengine.accessToken.trim());
+  if (s.provider === "elevenlabs") return Boolean(s.elevenlabs.apiKey.trim());
+  return false;
+}
+
+/**
+ * 组装 /api/tts 请求头。minimax 保持旧协议头（兼容服务端 env 与旧 MiniMax
+ * key 入口），其他 Provider 走 x-tts-* 头。
+ */
+export function buildTtsRequestHeaders(settings?: TtsSettings): Record<string, string> {
+  const s = settings ?? getTtsSettings();
+  if (s.provider === "minimax") {
+    // 旧入口的 MiniMax 自带 key（api-keys 存储）。项目模式下必须走服务端
+    // env（不带自定义头，服务端才会做对局授权校验），与旧行为保持一致。
+    if (getModelSource() === "project" || !hasMinimaxKey()) {
+      return {};
+    }
+    return {
+      "X-Minimax-Api-Key": getMinimaxApiKey(),
+      "X-Minimax-Group-Id": getMinimaxGroupId(),
+    };
+  }
+
+  const headers: Record<string, string> = { "X-TTS-Provider": s.provider };
+  if (s.provider === "openai-compatible") {
+    headers["X-TTS-Api-Key"] = s.openai.apiKey.trim();
+    if (s.openai.baseUrl.trim()) headers["X-TTS-Base-Url"] = s.openai.baseUrl.trim();
+    if (s.openai.model.trim()) headers["X-TTS-Model"] = s.openai.model.trim();
+  } else if (s.provider === "stepfun") {
+    headers["X-TTS-Api-Key"] = s.stepfun.apiKey.trim();
+    if (s.stepfun.baseUrl.trim()) headers["X-TTS-Base-Url"] = s.stepfun.baseUrl.trim();
+    if (s.stepfun.model.trim()) headers["X-TTS-Model"] = s.stepfun.model.trim();
+  } else if (s.provider === "volcengine") {
+    headers["X-TTS-App-Id"] = s.volcengine.appId.trim();
+    headers["X-TTS-Access-Token"] = s.volcengine.accessToken.trim();
+  } else if (s.provider === "elevenlabs") {
+    headers["X-TTS-Api-Key"] = s.elevenlabs.apiKey.trim();
+    if (s.elevenlabs.baseUrl.trim()) headers["X-TTS-Base-Url"] = s.elevenlabs.baseUrl.trim();
+    if (s.elevenlabs.model.trim()) headers["X-TTS-Model"] = s.elevenlabs.model.trim();
+  }
+  return headers;
+}
+
+export function getTtsCredentialsPreview(settings?: TtsSettings): TtsCredentials {
+  const s = settings ?? getTtsSettings();
+  if (s.provider === "openai-compatible") {
+    return { apiKey: s.openai.apiKey, baseUrl: s.openai.baseUrl, model: s.openai.model };
+  }
+  if (s.provider === "stepfun") {
+    return { apiKey: s.stepfun.apiKey, baseUrl: s.stepfun.baseUrl, model: s.stepfun.model };
+  }
+  if (s.provider === "volcengine") {
+    return { appId: s.volcengine.appId, accessToken: s.volcengine.accessToken };
+  }
+  if (s.provider === "elevenlabs") {
+    return { apiKey: s.elevenlabs.apiKey, baseUrl: s.elevenlabs.baseUrl, model: s.elevenlabs.model };
+  }
+  return {};
+}
+
+export interface TtsProbeResult {
+  ok: boolean;
+  error?: string;
+}
+
+/** 连通性测试：让 /api/tts 用当前配置合成一句短语。 */
+export async function probeTtsProvider(settings?: TtsSettings): Promise<TtsProbeResult> {
+  const s = settings ?? getTtsSettings();
+  try {
+    const { getAuthHeaders } = await import("@/lib/auth-headers");
+    const response = await fetch("/api/tts", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...buildTtsRequestHeaders(s),
+        ...(await getAuthHeaders()),
+      },
+      body: JSON.stringify({ probe: true, locale: "zh" }),
+    });
+    if (!response.ok) {
+      const data = (await response.json().catch(() => null)) as { error?: string } | null;
+      return { ok: false, error: data?.error || `HTTP ${response.status}` };
+    }
+    const data = (await response.json().catch(() => null)) as { ok?: boolean; error?: string } | null;
+    if (data?.ok) return { ok: true };
+    return { ok: false, error: data?.error || "验证失败" };
+  } catch (error) {
+    return { ok: false, error: `连接失败: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 音色预设
+// ---------------------------------------------------------------------------
+
+const OPENAI_VOICE_PRESETS: VoicePreset[] = [
+  { id: "alloy", name: "Alloy", styles: ["balanced"], gender: "female" },
+  { id: "ash", name: "Ash", styles: ["calm"], gender: "male" },
+  { id: "ballad", name: "Ballad", styles: ["cheerful"], gender: "male" },
+  { id: "coral", name: "Coral", styles: ["warm"], gender: "female" },
+  { id: "echo", name: "Echo", styles: ["logic"], gender: "male" },
+  { id: "fable", name: "Fable", styles: ["storytelling"], gender: "male" },
+  { id: "onyx", name: "Onyx", styles: ["deep"], gender: "male" },
+  { id: "nova", name: "Nova", styles: ["bright"], gender: "female" },
+  { id: "sage", name: "Sage", styles: ["calm"], gender: "female" },
+  { id: "shimmer", name: "Shimmer", styles: ["soft"], gender: "female" },
+];
+
+const VOLCENGINE_VOICE_PRESETS: VoicePreset[] = [
+  // 音色 ID 以火山引擎控制台开通列表为准（voice_type）
+  { id: "zh_female_shuangkuaisisi_mars_bigtts", name: "爽快思思", styles: ["cheerful"], gender: "female" },
+  { id: "zh_female_rouqingmeimei_mars_bigtts", name: "柔软妹妹", styles: ["safe", "soft"], gender: "female" },
+  { id: "zh_female_wanqudashu_mars_bigtts", name: "湾曲大叔", styles: ["calm"], gender: "male" },
+  { id: "zh_male_beijingxiaoye_mars_bigtts", name: "北京小爷", styles: ["aggressive"], gender: "male" },
+  { id: "zh_female_cancan_mars_bigtts", name: "灿灿", styles: ["balanced"], gender: "female" },
+  { id: "zh_male_dayi_mars_bigtts", name: "大力", styles: ["logic"], gender: "male" },
+];
+
+const ELEVENLABS_VOICE_PRESETS: VoicePreset[] = [
+  { id: "21m00Tcm4TlvDq8ikWAM", name: "Rachel", styles: ["calm"], gender: "female" },
+  { id: "EXAVITQu4vr4xnSDxMaL", name: "Sarah", styles: ["soft"], gender: "female" },
+  { id: "FGY2WhTYpPnrIDTdsKH5", name: "Laura", styles: ["cheerful"], gender: "female" },
+  { id: "LcfcDJNUP1GQjkzn1xUU", name: "Emily", styles: ["balanced"], gender: "female" },
+  { id: "JBFqnCBsd6RMkjVDRZzb", name: "George", styles: ["balanced"], gender: "male" },
+  { id: "IKne3meq5aSn9XLyUdCD", name: "Charlie", styles: ["aggressive"], gender: "male" },
+  { id: "N2lVS1w4EtoT3dr4eOWO", name: "Callum", styles: ["intense"], gender: "male" },
+  { id: "TX3LPaxmHKxFdv7VOQHJ", name: "Liam", styles: ["young"], gender: "male" },
+];
+
+const PROVIDER_PRESETS: Record<Exclude<TtsProviderId, "minimax">, { zh: VoicePreset[]; en: VoicePreset[] }> = {
+  "openai-compatible": { zh: OPENAI_VOICE_PRESETS, en: OPENAI_VOICE_PRESETS },
+  stepfun: { zh: STEPFUN_VOICE_PRESETS, en: STEPFUN_ENGLISH_VOICE_PRESETS },
+  volcengine: { zh: VOLCENGINE_VOICE_PRESETS, en: VOLCENGINE_VOICE_PRESETS },
+  elevenlabs: { zh: ELEVENLABS_VOICE_PRESETS, en: ELEVENLABS_VOICE_PRESETS },
+};
+
+export function getVoicePresetsForProvider(provider: TtsProviderId, locale: AppLocale): VoicePreset[] {
+  if (provider === "minimax") {
+    return locale === "en" ? ENGLISH_VOICE_PRESETS : VOICE_PRESETS;
+  }
+  return PROVIDER_PRESETS[provider][locale] ?? PROVIDER_PRESETS[provider].zh;
+}
+
+export function getDefaultVoiceForProvider(provider: TtsProviderId, locale: AppLocale): string {
+  if (provider === "minimax") {
+    return locale === "en" ? DEFAULT_VOICE_ID_EN.male : DEFAULT_VOICE_ID.male;
+  }
+  return getVoicePresetsForProvider(provider, locale)[0]?.id ?? "";
+}
+
+/**
+ * 与 voice-constants 的 resolveVoiceId 语义一致，但按当前 TTS Provider
+ * 的音色表解析。旧存档里残留的其他 Provider 音色 ID 会被归一化为当前
+ * Provider 的合法音色，避免播放失败。
+ */
+export function resolveVoiceIdForActiveProvider(
+  input: string | undefined,
+  gender: "male" | "female" | "nonbinary" | undefined,
+  age?: number,
+  locale: AppLocale = "zh",
+  /** 确定性种子：同一角色跨台词、跨会话保持同一音色（默认用输入 ID） */
+  seed?: string,
+): string {
+  const settings = getTtsSettings();
+  const normGender: "male" | "female" = gender === "female" ? "female" : "male";
+  const presets = getVoicePresetsForProvider(settings.provider, locale);
+  const fallback = getDefaultVoiceForProvider(settings.provider, locale);
+  const trimmed = (input || "").trim();
+
+  if (settings.provider === "minimax") {
+    // 与旧逻辑完全一致：合法 ID 直接用，否则按性别/年龄挑预设
+    if (locale === "zh" && trimmed && presets.some((p) => p.id === trimmed)) {
+      return trimmed;
+    }
+    return pickByGenderAge(presets, normGender, age, fallback);
+  }
+
+  // 非 MiniMax：输入命中当前 Provider 音色表则使用；否则按种子稳定映射，
+  // 避免旧存档的异 Provider 音色 ID 导致每句台词换声。
+  if (trimmed && presets.some((p) => p.id === trimmed)) {
+    return trimmed;
+  }
+  return pickByGenderAge(presets, normGender, age, fallback, seed ?? trimmed);
+}
+
+function pickByGenderAge(
+  presets: VoicePreset[],
+  gender: "male" | "female",
+  age: number | undefined,
+  fallback: string,
+  seed?: string,
+): string {
+  const byGender = presets.filter((p) => p.gender === gender);
+  const pool = byGender.length > 0 ? byGender : presets;
+  const hasAge = typeof age === "number" && Number.isFinite(age);
+  const aged = hasAge
+    ? pool.filter((p) => {
+        const minOk = typeof p.minAge === "number" ? age >= p.minAge : true;
+        const maxOk = typeof p.maxAge === "number" ? age <= p.maxAge : true;
+        return minOk && maxOk;
+      })
+    : [];
+  const finalPool = aged.length > 0 ? aged : pool;
+
+  if (seed) {
+    // FNV-1a 哈希做确定性选择
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < seed.length; i++) {
+      hash ^= seed.charCodeAt(i);
+      hash = Math.imul(hash, 0x01000193);
+    }
+    const index = Math.abs(hash) % finalPool.length;
+    return finalPool[index]?.id ?? fallback;
+  }
+  return finalPool[Math.floor(Math.random() * finalPool.length)]?.id ?? fallback;
+}
+

--- a/src/lib/tts/audio-util.ts
+++ b/src/lib/tts/audio-util.ts
@@ -1,0 +1,123 @@
+import type { IncomingHttpHeaders } from "node:http";
+import * as https from "node:https";
+import { URL } from "node:url";
+import * as zlib from "node:zlib";
+
+/** 服务端 HTTPS 请求，返回解压后的 body（旧 /api/tts 路由的同款实现）。 */
+export async function requestBuffer(
+  inputUrl: string,
+  init: {
+    method: "GET" | "POST";
+    headers?: Record<string, string>;
+    body?: string;
+    timeoutMs: number;
+  },
+): Promise<{ statusCode: number; headers: IncomingHttpHeaders; body: Buffer }> {
+  const u = new URL(inputUrl);
+  if (u.protocol !== "https:") {
+    throw new Error(`Unsupported protocol: ${u.protocol}`);
+  }
+
+  return await new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        protocol: u.protocol,
+        hostname: u.hostname,
+        port: u.port ? Number(u.port) : 443,
+        path: `${u.pathname}${u.search}`,
+        method: init.method,
+        headers: init.headers,
+        family: 4,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c)));
+        res.on("end", () => {
+          const raw = Buffer.concat(chunks);
+
+          const enc = res.headers["content-encoding"];
+          const encStr = Array.isArray(enc) ? enc.join(",") : enc;
+
+          let body = raw;
+          try {
+            if (typeof encStr === "string" && encStr) {
+              const e = encStr.toLowerCase();
+              if (e.includes("br")) body = zlib.brotliDecompressSync(raw);
+              else if (e.includes("gzip")) body = zlib.gunzipSync(raw);
+              else if (e.includes("deflate")) body = zlib.inflateSync(raw);
+            }
+          } catch (decompressErr) {
+            // 解压失败就回退到原始内容，并在上层用可读错误定位
+            console.error("TTS response decompress failed:", decompressErr);
+            body = raw;
+          }
+
+          resolve({
+            statusCode: res.statusCode || 0,
+            headers: res.headers,
+            body,
+          });
+        });
+      },
+    );
+
+    req.on("error", reject);
+    req.setTimeout(init.timeoutMs, () => {
+      req.destroy(new Error("RequestTimeout"));
+    });
+
+    if (init.body) req.write(init.body);
+    req.end();
+  });
+}
+
+export function bufferToArrayBuffer(b: Buffer): ArrayBuffer {
+  const ab = new ArrayBuffer(b.byteLength);
+  new Uint8Array(ab).set(b);
+  return ab;
+}
+
+/** 通过魔数识别音频容器类型；识别不出时返回 null。 */
+export function sniffAudioMime(b: Buffer): { mime: string | null; reason?: string } {
+  if (!b || b.length < 4) return { mime: null, reason: "empty_or_too_short" };
+
+  // WAV: RIFF....WAVE
+  if (b.length >= 12 && b.slice(0, 4).toString("ascii") === "RIFF" && b.slice(8, 12).toString("ascii") === "WAVE") {
+    return { mime: "audio/wav" };
+  }
+
+  // OGG
+  if (b.slice(0, 4).toString("ascii") === "OggS") {
+    return { mime: "audio/ogg" };
+  }
+
+  // MP3: ID3 tag or frame sync 0xFFE?
+  if (b.slice(0, 3).toString("ascii") === "ID3") {
+    return { mime: "audio/mpeg" };
+  }
+  if (b[0] === 0xff && (b[1] & 0xe0) === 0xe0) {
+    return { mime: "audio/mpeg" };
+  }
+
+  // If it looks like text/json, treat as non-audio
+  const head = b.slice(0, 64).toString("utf8").trim();
+  if (head.startsWith("{") || head.startsWith("[") || head.toLowerCase().includes("error")) {
+    return { mime: null, reason: "looks_like_text_or_json" };
+  }
+
+  return { mime: null, reason: "unknown_format" };
+}
+
+/** 优先信任响应头 Content-Type，其次魔数嗅探。 */
+export function resolveAudioMime(buffer: Buffer, contentType: unknown): string | null {
+  if (typeof contentType === "string") {
+    const ct = contentType.split(";")[0].trim().toLowerCase();
+    if (ct === "audio/mpeg" || ct === "audio/mp3" || ct === "audio/wav" || ct === "audio/ogg" || ct === "audio/aac" || ct === "audio/opus") {
+      return ct === "audio/mp3" ? "audio/mpeg" : ct;
+    }
+    if (ct === "application/json" || ct.startsWith("text/")) {
+      return null;
+    }
+  }
+  return sniffAudioMime(buffer).mime;
+}

--- a/src/lib/tts/elevenlabs.ts
+++ b/src/lib/tts/elevenlabs.ts
@@ -1,0 +1,80 @@
+import {
+  requestBuffer,
+  resolveAudioMime,
+} from "./audio-util";
+import {
+  type TtsAdapter,
+  type TtsAudioResult,
+  type TtsSynthesizeInput,
+  TtsProviderError,
+} from "./types";
+import { joinProviderUrl } from "@/lib/custom-providers";
+
+const TTS_TIMEOUT_MS = 30_000;
+const DEFAULT_BASE_URL = "https://api.elevenlabs.io";
+const DEFAULT_MODEL = "eleven_multilingual_v2";
+/** 免费可用的预置音色（Rachel）；未知音色一律回退到它 */
+const FALLBACK_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
+
+/** ElevenLabs REST TTS：按 voiceId 路径合成，xi-api-key 鉴权。 */
+export const elevenlabsAdapter: TtsAdapter = {
+  id: "elevenlabs",
+  defaultVoiceId() {
+    return FALLBACK_VOICE_ID;
+  },
+
+  async synthesize(input: TtsSynthesizeInput, credentials): Promise<TtsAudioResult> {
+    const apiKey = credentials.apiKey?.trim();
+    if (!apiKey) {
+      throw new TtsProviderError("ElevenLabs TTS 需要 API Key", 400);
+    }
+
+    const baseUrl = credentials.baseUrl?.trim() || DEFAULT_BASE_URL;
+    const voice = input.voiceId.trim() || this.defaultVoiceId(input.locale);
+    const outputFormat = "mp3_44100_128";
+
+    const synthesizeOnce = async (voiceId: string) => {
+      const url = joinProviderUrl(baseUrl, `v1/text-to-speech/${encodeURIComponent(voiceId)}`);
+      if (!url) throw new TtsProviderError("Invalid TTS Base URL", 400);
+      return requestBuffer(`${url}?output_format=${outputFormat}`, {
+        method: "POST",
+        headers: {
+          "xi-api-key": apiKey,
+          "Content-Type": "application/json",
+          Accept: "audio/mpeg",
+        },
+        body: JSON.stringify({
+          text: input.text,
+          model_id: credentials.model?.trim() || DEFAULT_MODEL,
+        }),
+        timeoutMs: TTS_TIMEOUT_MS,
+      });
+    };
+
+    let response = await synthesizeOnce(voice);
+
+    // 音色无效（400/404/422）时回退到预置音色重试一次
+    if ([400, 404, 422].includes(response.statusCode) && voice !== this.defaultVoiceId(input.locale)) {
+      console.warn("[tts/elevenlabs] voice rejected, retrying with default voice");
+      response = await synthesizeOnce(this.defaultVoiceId(input.locale));
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new TtsProviderError(
+        `ElevenLabs TTS 请求失败（HTTP ${response.statusCode}）`,
+        response.statusCode,
+        response.body.slice(0, 300).toString("utf8"),
+      );
+    }
+
+    const mime = resolveAudioMime(response.body, response.headers["content-type"]);
+    if (!mime) {
+      throw new TtsProviderError(
+        "TTS audio is not in a supported format.",
+        502,
+        response.body.slice(0, 300).toString("utf8"),
+      );
+    }
+    return { audio: response.body, mime };
+  },
+};

--- a/src/lib/tts/minimax.ts
+++ b/src/lib/tts/minimax.ts
@@ -1,0 +1,260 @@
+import { DEFAULT_VOICE_ID, DEFAULT_VOICE_ID_EN } from "@/lib/voice-constants";
+import {
+  requestBuffer,
+  sniffAudioMime,
+} from "./audio-util";
+import {
+  type TtsAdapter,
+  type TtsAudioResult,
+  type TtsCredentials,
+  type TtsSynthesizeInput,
+  TtsProviderError,
+} from "./types";
+
+const TTS_TIMEOUT_MS = 30_000;
+
+interface MiniMaxCredentials extends TtsCredentials {
+  apiKey: string;
+  groupId: string;
+}
+
+const asMiniMax = (c: TtsCredentials): MiniMaxCredentials | null =>
+  c.apiKey && c.groupId ? { ...c, apiKey: c.apiKey, groupId: c.groupId } : null;
+
+function pickFallbackVoiceId(badVoiceId: string): string {
+  const v = badVoiceId.toLowerCase();
+  if (v.startsWith("female") || v.includes("female")) return DEFAULT_VOICE_ID.female;
+  return DEFAULT_VOICE_ID.male;
+}
+
+/**
+ * MiniMax T2A V2。保留旧 /api/tts 路由的全部健壮性逻辑：
+ * 双域名兜底、2054 音色无效自动回退、audio url / hex / base64 三种返回形态。
+ * 参考文档：https://platform.minimaxi.com/document/T2A%20V2
+ */
+export const minimaxAdapter: TtsAdapter = {
+  id: "minimax",
+  defaultVoiceId(locale) {
+    return locale === "en" ? DEFAULT_VOICE_ID_EN.male : DEFAULT_VOICE_ID.male;
+  },
+
+  async synthesize(input: TtsSynthesizeInput, credentials): Promise<TtsAudioResult> {
+    const creds = asMiniMax(credentials);
+    if (!creds) {
+      throw new TtsProviderError("MiniMax API key and group ID are both required", 400);
+    }
+
+    const baseUrlFromEnv = process.env.MINIMAX_API_BASE_URL;
+    const primaryBaseUrl = baseUrlFromEnv || creds.baseUrl || "https://api.minimax.chat";
+
+    const candidateBaseUrls = [primaryBaseUrl];
+    if (!baseUrlFromEnv && !creds.baseUrl) {
+      // 自动兜底另一个域名，避免因为平台（minimax.chat vs minimaxi.com）差异导致连不通
+      candidateBaseUrls.push(
+        primaryBaseUrl.includes("minimaxi.com")
+          ? "https://api.minimax.chat"
+          : "https://api.minimaxi.com",
+      );
+    }
+
+    const payload = {
+      model: creds.model || process.env.MINIMAX_TTS_MODEL || "speech-01-turbo",
+      text: input.text,
+      stream: false,
+      voice_setting: {
+        voice_id: input.voiceId,
+        speed: 1.0,
+        vol: 1.0,
+        pitch: 0,
+      },
+      audio_setting: {
+        sample_rate: 32000,
+        bitrate: 128000,
+        format: "mp3",
+        channel: 1,
+      },
+    };
+
+    let usedVoiceId = input.voiceId;
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const response = await requestMiniMaxCompletion(creds, candidateBaseUrls, payload, usedVoiceId);
+
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        const errorText = response.body.toString("utf8");
+        console.error("MiniMax API Error:", response.statusCode, errorText);
+        throw new TtsProviderError(`MiniMax API error: ${errorText}`, response.statusCode || 502);
+      }
+
+      const contentType = response.headers["content-type"];
+      if (typeof contentType === "string" && contentType.includes("application/json")) {
+        let json: unknown;
+        try {
+          json = JSON.parse(response.body.toString("utf8"));
+        } catch (e) {
+          const preview = response.body.slice(0, 600).toString("utf8");
+          console.error("MiniMax JSON parse failed:", e, { preview });
+          throw new TtsProviderError("MiniMax JSON parse failed", 502, preview);
+        }
+
+        const jsonRecord = (json ?? {}) as Record<string, unknown>;
+        const baseResp = jsonRecord.base_resp as Record<string, unknown> | undefined;
+        if (baseResp && Number(baseResp.status_code) !== 0) {
+          const code = Number(baseResp.status_code);
+          const msg = String(baseResp.status_msg || "");
+
+          if (code === 2054 && attempt === 0) {
+            const fallback = pickFallbackVoiceId(usedVoiceId);
+            if (fallback !== usedVoiceId) {
+              usedVoiceId = fallback;
+              continue;
+            }
+          }
+
+          console.error("MiniMax base_resp error:", {
+            status_code: code,
+            status_msg: msg,
+            voiceId: usedVoiceId,
+            textPreview: input.text.slice(0, 200),
+          });
+          throw new TtsProviderError(
+            "MiniMax base_resp error",
+            502,
+            JSON.stringify({ status_code: code, status_msg: msg, voiceId: usedVoiceId }),
+          );
+        }
+
+        const audio = await extractMiniMaxAudio(jsonRecord, response.body);
+        return { audio, mime: sniffAudioMime(audio).mime ?? "audio/mpeg" };
+      }
+
+      // 二进制响应
+      return {
+        audio: response.body,
+        mime: sniffAudioMime(response.body).mime ?? "audio/mpeg",
+      };
+    }
+
+    throw new TtsProviderError("MiniMax voiceId retry exhausted", 502, usedVoiceId);
+  },
+};
+
+async function requestMiniMaxCompletion(
+  creds: MiniMaxCredentials,
+  candidateBaseUrls: string[],
+  payload: Record<string, unknown>,
+  voiceId: string,
+) {
+  const body = JSON.stringify({
+    ...payload,
+    voice_setting: {
+      ...((payload.voice_setting as Record<string, unknown> | undefined) ?? {}),
+      voice_id: voiceId,
+    },
+  });
+
+  let response: Awaited<ReturnType<typeof requestBuffer>> | null = null;
+  let lastError: unknown = null;
+
+  for (const baseUrl of candidateBaseUrls) {
+    const url = `${baseUrl}/v1/t2a_v2?GroupId=${encodeURIComponent(creds.groupId)}`;
+    try {
+      response = await requestBuffer(url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${creds.apiKey}`,
+          "Content-Type": "application/json",
+          GroupId: creds.groupId,
+          "Accept-Encoding": "identity",
+        },
+        body,
+        timeoutMs: TTS_TIMEOUT_MS,
+      });
+      break;
+    } catch (e) {
+      lastError = e;
+      continue;
+    }
+  }
+
+  if (!response) {
+    const attempted = candidateBaseUrls.join(", ");
+    console.error("MiniMax fetch failed. attempted base urls:", attempted, lastError);
+    throw new TtsProviderError(
+      "MiniMax fetch failed (connect timeout / network). Please set MINIMAX_API_BASE_URL to the correct domain (https://api.minimaxi.com or https://api.minimax.chat).",
+      502,
+    );
+  }
+
+  return response;
+}
+
+async function extractMiniMaxAudio(
+  json: Record<string, unknown>,
+  rawBody: Buffer,
+): Promise<Buffer> {
+  const isRecord = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null;
+
+  const dataRecord = isRecord(json.data) ? json.data : null;
+  const audioRecord = isRecord(json.audio) ? json.audio : null;
+  const dataStr: unknown =
+    (typeof json.data === "string" ? json.data : undefined) ??
+    dataRecord?.audio ??
+    dataRecord?.data ??
+    audioRecord?.data ??
+    json.audio_data;
+
+  const audioUrl: unknown = audioRecord?.url ?? dataRecord?.url ?? json.url;
+
+  if (typeof audioUrl === "string" && audioUrl.startsWith("http")) {
+    const audioResp = await requestBuffer(audioUrl, {
+      method: "GET",
+      headers: { "Accept-Encoding": "identity" },
+      timeoutMs: TTS_TIMEOUT_MS,
+    });
+    if (audioResp.statusCode < 200 || audioResp.statusCode >= 300) {
+      throw new TtsProviderError(`MiniMax audio url fetch failed: ${audioResp.statusCode}`);
+    }
+    return audioResp.body;
+  }
+
+  if (typeof dataStr === "string" && dataStr.trim()) {
+    const t = dataStr.trim();
+
+    const maybeB64 = t.startsWith("data:") ? t.split(",").slice(1).join(",") : t;
+    const looksLikeBase64 = /[+/=]/.test(maybeB64);
+    const looksLikeHex = !looksLikeBase64 && /^[0-9a-fA-F]+$/.test(t) && t.length % 2 === 0;
+
+    let buffer: Buffer;
+    let altBuffer: Buffer | null = null;
+
+    if (looksLikeHex) {
+      buffer = Buffer.from(t, "hex");
+      try {
+        altBuffer = Buffer.from(maybeB64, "base64");
+      } catch {
+        altBuffer = null;
+      }
+    } else {
+      buffer = Buffer.from(maybeB64, "base64");
+      if (/^[0-9a-fA-F]+$/.test(t) && t.length % 2 === 0) {
+        try {
+          altBuffer = Buffer.from(t, "hex");
+        } catch {
+          altBuffer = null;
+        }
+      }
+    }
+
+    const primarySniff = sniffAudioMime(buffer);
+    if (!primarySniff.mime && altBuffer) {
+      const altSniff = sniffAudioMime(altBuffer);
+      if (altSniff.mime) {
+        buffer = altBuffer;
+      }
+    }
+    return buffer;
+  }
+
+  return rawBody;
+}

--- a/src/lib/tts/openai-compatible.ts
+++ b/src/lib/tts/openai-compatible.ts
@@ -1,0 +1,120 @@
+import {
+  requestBuffer,
+  resolveAudioMime,
+} from "./audio-util";
+import {
+  type TtsAdapter,
+  type TtsProviderId,
+  type TtsAudioResult,
+  type TtsSynthesizeInput,
+  TtsProviderError,
+} from "./types";
+import { joinProviderUrl } from "@/lib/custom-providers";
+
+const TTS_TIMEOUT_MS = 30_000;
+
+const DEFAULT_MODEL = "gpt-4o-mini-tts";
+const DEFAULT_VOICE = "alloy";
+
+/**
+ * OpenAI /audio/speech 兼容格式的适配器工厂。
+ * 一个形状覆盖 OpenAI 官方、硅基流动、Fish Audio、阶跃星辰 StepFun 及各类
+ * 自部署网关（GPT-SoVITS、index-tts 等的兼容层）。
+ * 语音参数：model + input + voice + response_format。
+ */
+export interface OpenAiSpeechAdapterConfig {
+  id: TtsProviderId;
+  defaultBaseUrl: string;
+  defaultModel: string;
+  defaultVoiceId: string;
+  logTag: string;
+  missingKeyMessage: string;
+}
+
+export function createOpenAiSpeechAdapter(config: OpenAiSpeechAdapterConfig): TtsAdapter {
+  return {
+    id: config.id,
+    defaultVoiceId() {
+      return config.defaultVoiceId;
+    },
+
+    async synthesize(input: TtsSynthesizeInput, credentials): Promise<TtsAudioResult> {
+      const apiKey = credentials.apiKey?.trim();
+      if (!apiKey) {
+        throw new TtsProviderError(config.missingKeyMessage, 400);
+      }
+      const baseUrl = credentials.baseUrl?.trim() || config.defaultBaseUrl;
+      const speechUrl = joinProviderUrl(baseUrl, "audio/speech");
+      if (!speechUrl) {
+        throw new TtsProviderError("Invalid TTS Base URL", 400);
+      }
+
+      const voice = input.voiceId.trim() || this.defaultVoiceId(input.locale);
+
+      const first = await requestSpeech(speechUrl, apiKey, {
+        model: credentials.model?.trim() || config.defaultModel,
+        input: input.text,
+        voice,
+        response_format: "mp3",
+      });
+
+      if (first.statusCode >= 200 && first.statusCode < 300) {
+        const mime = resolveAudioMime(first.body, first.headers["content-type"]);
+        if (mime) return { audio: first.body, mime };
+        throw new TtsProviderError("TTS audio is not in a supported format.", 502, first.body.slice(0, 300).toString("utf8"));
+      }
+
+      // 音色无效时回退到默认音色重试一次（各网关对未知 voice 的报错形态不一）
+      const errorText = first.body.slice(0, 400).toString("utf8").toLowerCase();
+      if (voice !== this.defaultVoiceId(input.locale) && (first.statusCode === 400 || first.statusCode === 404)) {
+        console.warn(`[tts/${config.logTag}] voice rejected, retrying with default:`, errorText.slice(0, 200));
+        const retry = await requestSpeech(speechUrl, apiKey, {
+          model: credentials.model?.trim() || config.defaultModel,
+          input: input.text,
+          voice: this.defaultVoiceId(input.locale),
+          response_format: "mp3",
+        });
+        if (retry.statusCode >= 200 && retry.statusCode < 300) {
+          const mime = resolveAudioMime(retry.body, retry.headers["content-type"]);
+          if (mime) return { audio: retry.body, mime };
+        }
+        throw new TtsProviderError(
+          `TTS 请求失败（HTTP ${retry.statusCode}）`,
+          retry.statusCode,
+          retry.body.slice(0, 300).toString("utf8"),
+        );
+      }
+
+      throw new TtsProviderError(
+        `TTS 请求失败（HTTP ${first.statusCode}）`,
+        first.statusCode,
+        errorText,
+      );
+    },
+  };
+}
+
+export const openaiCompatibleAdapter: TtsAdapter = createOpenAiSpeechAdapter({
+  id: "openai-compatible",
+  defaultBaseUrl: "https://api.openai.com/v1",
+  defaultModel: DEFAULT_MODEL,
+  defaultVoiceId: DEFAULT_VOICE,
+  logTag: "openai-compatible",
+  missingKeyMessage: "OpenAI 兼容 TTS 需要 API Key",
+});
+
+async function requestSpeech(
+  url: string,
+  apiKey: string,
+  body: Record<string, unknown>,
+) {
+  return requestBuffer(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    timeoutMs: TTS_TIMEOUT_MS,
+  });
+}

--- a/src/lib/tts/registry.ts
+++ b/src/lib/tts/registry.ts
@@ -1,0 +1,22 @@
+import type { TtsAdapter, TtsProviderId } from "./types";
+import { minimaxAdapter } from "./minimax";
+import { openaiCompatibleAdapter } from "./openai-compatible";
+import { stepfunAdapter } from "./stepfun";
+import { volcengineAdapter } from "./volcengine";
+import { elevenlabsAdapter } from "./elevenlabs";
+
+const ADAPTERS: Record<TtsProviderId, TtsAdapter> = {
+  minimax: minimaxAdapter,
+  "openai-compatible": openaiCompatibleAdapter,
+  stepfun: stepfunAdapter,
+  volcengine: volcengineAdapter,
+  elevenlabs: elevenlabsAdapter,
+};
+
+export function getTtsAdapter(id: TtsProviderId): TtsAdapter {
+  return ADAPTERS[id] ?? minimaxAdapter;
+}
+
+export function isTtsProviderId(value: string): value is TtsProviderId {
+  return value in ADAPTERS;
+}

--- a/src/lib/tts/stepfun-voices.ts
+++ b/src/lib/tts/stepfun-voices.ts
@@ -1,0 +1,47 @@
+import type { VoicePreset } from "@/lib/voice-constants";
+
+/**
+ * StepFun 官方音色预设（纯数据，客户端可用；不要在此引入服务端适配器）。
+ * 音色与描述来自 StepFun system_voices 接口与官方文档。
+ */
+
+export const STEPFUN_VOICE_PRESETS: VoicePreset[] = [
+  // --- 男性音色 ---
+  { id: "cixingnansheng", name: "磁性男声", styles: ["deep", "霸总"], gender: "male" },
+  { id: "zhengpaiqingnian", name: "正派青年", styles: ["cheerful", "balanced"], gender: "male" },
+  { id: "zixinnansheng", name: "自信男声", styles: ["balanced", "logic"], gender: "male" },
+  { id: "yuanqinansheng", name: "元气男声", styles: ["cheerful", "energetic"], gender: "male" },
+  { id: "boyinnansheng", name: "播音男声", styles: ["calm", "logic"], gender: "male" },
+  { id: "wenrougongzi", name: "温柔公子", styles: ["calm", "gentle"], gender: "male" },
+  { id: "shenchennanyin", name: "深沉男音", styles: ["deep", "steady"], gender: "male" },
+  { id: "wenrounansheng", name: "温柔男声", styles: ["safe", "gentle"], gender: "male" },
+  { id: "qingniandaxuesheng", name: "青年大学生", styles: ["young", "logic"], gender: "male" },
+  { id: "ruyananshi", name: "儒雅男士", styles: ["calm", "scholar"], gender: "male" },
+  { id: "shuangkuainansheng", name: "爽快男声", styles: ["aggressive", "balanced"], gender: "male" },
+
+  // --- 女性音色 ---
+  { id: "linjiajiejie", name: "邻家姐姐", styles: ["safe", "warm"], gender: "female" },
+  { id: "linjiameimei", name: "邻家妹妹", styles: ["cheerful", "cute"], gender: "female" },
+  { id: "ruanmengnvsheng", name: "软萌女声", styles: ["cute", "soft"], gender: "female" },
+  { id: "shuangkuaijiejie", name: "爽快姐姐", styles: ["cheerful", "balanced"], gender: "female" },
+  { id: "wenjingxuejie", name: "文静学姐", styles: ["calm", "logic"], gender: "female" },
+  { id: "qingchunshaonv", name: "清纯少女", styles: ["soft", "young"], gender: "female" },
+  { id: "tianmeinvsheng", name: "甜美女声", styles: ["sweet", "safe"], gender: "female" },
+  { id: "lengyanyujie", name: "冷艳御姐", styles: ["aggressive", "cool"], gender: "female" },
+  { id: "jilingshaonv", name: "机灵少女", styles: ["cheerful", "young"], gender: "female" },
+  { id: "huolinvsheng", name: "活力女声", styles: ["cheerful", "energetic"], gender: "female" },
+  { id: "yuanqishaonv", name: "元气少女", styles: ["cheerful", "cute"], gender: "female" },
+  { id: "youyanvsheng", name: "优雅女声", styles: ["calm", "elegant"], gender: "female" },
+  { id: "qinqienvsheng", name: "亲切女声", styles: ["safe", "warm"], gender: "female" },
+  { id: "wenroushunv", name: "温柔熟女", styles: ["calm", "mature"], gender: "female" },
+  { id: "ganliannvsheng", name: "干练女声", styles: ["logic", "professional"], gender: "female" },
+];
+
+export const STEPFUN_ENGLISH_VOICE_PRESETS: VoicePreset[] = [
+  { id: "vibrant-youth", name: "Vibrant Youth", styles: ["balanced"], gender: "male" },
+  { id: "soft-spoken-gentleman", name: "Soft-spoken Gentleman", styles: ["calm"], gender: "male" },
+  { id: "magnetic-voiced-male", name: "Magnetic-voiced Male", styles: ["deep"], gender: "male" },
+  { id: "energeticconfident-female", name: "Energetic Confident", styles: ["cheerful"], gender: "female" },
+  { id: "lively-girl", name: "Lively Girl", styles: ["cheerful"], gender: "female" },
+  { id: "elegantgentle-female", name: "Elegant Gentle", styles: ["calm"], gender: "female" },
+];

--- a/src/lib/tts/stepfun.ts
+++ b/src/lib/tts/stepfun.ts
@@ -1,0 +1,22 @@
+import { createOpenAiSpeechAdapter } from "./openai-compatible";
+
+/**
+ * 阶跃星辰 StepFun TTS。OpenAI /audio/speech 兼容形状：
+ * POST {base}/audio/speech {model, input, voice, response_format}。
+ * 模型：step-tts-mini / step-tts-2 / stepaudio-2.5-tts。
+ * Step Plan 订阅需使用 https://api.stepfun.com/step_plan/v1 作为 Base URL。
+ * 音色预设（客户端可用）见 ./stepfun-voices。
+ */
+
+export const STEPFUN_DEFAULT_BASE_URL = "https://api.stepfun.com/v1";
+export const STEPFUN_DEFAULT_MODEL = "step-tts-mini";
+export const STEPFUN_DEFAULT_VOICE = "cixingnansheng";
+
+export const stepfunAdapter = createOpenAiSpeechAdapter({
+  id: "stepfun",
+  defaultBaseUrl: STEPFUN_DEFAULT_BASE_URL,
+  defaultModel: STEPFUN_DEFAULT_MODEL,
+  defaultVoiceId: STEPFUN_DEFAULT_VOICE,
+  logTag: "stepfun",
+  missingKeyMessage: "StepFun TTS 需要 API Key",
+});

--- a/src/lib/tts/types.ts
+++ b/src/lib/tts/types.ts
@@ -1,0 +1,48 @@
+export type TtsProviderId = "minimax" | "openai-compatible" | "stepfun" | "volcengine" | "elevenlabs";
+
+export type TtsLocale = "zh" | "en";
+
+/** 各 Provider 的鉴权/端点配置；由客户端通过请求头透传或服务端环境变量兜底。 */
+export interface TtsCredentials {
+  apiKey?: string;
+  /** 仅 MiniMax 需要 */
+  groupId?: string;
+  /** OpenAI 兼容 / ElevenLabs 的自定义端点 */
+  baseUrl?: string;
+  /** OpenAI 兼容（如 gpt-4o-mini-tts）或 ElevenLabs 模型（如 eleven_multilingual_v2） */
+  model?: string;
+  /** 仅火山引擎需要 */
+  appId?: string;
+  /** 仅火山引擎需要 */
+  accessToken?: string;
+}
+
+export interface TtsSynthesizeInput {
+  text: string;
+  voiceId: string;
+  locale?: TtsLocale;
+}
+
+export interface TtsAudioResult {
+  audio: Buffer;
+  mime: string;
+}
+
+export interface TtsAdapter {
+  id: TtsProviderId;
+  /** 该 Provider 的兜底音色；音色无效或跨 Provider 残留旧 ID 时使用 */
+  defaultVoiceId(locale?: TtsLocale): string;
+  synthesize(input: TtsSynthesizeInput, credentials: TtsCredentials): Promise<TtsAudioResult>;
+}
+
+export class TtsProviderError extends Error {
+  readonly status: number;
+  readonly detail?: string;
+
+  constructor(message: string, status = 502, detail?: string) {
+    super(message);
+    this.name = "TtsProviderError";
+    this.status = status;
+    this.detail = detail;
+  }
+}

--- a/src/lib/tts/volcengine.ts
+++ b/src/lib/tts/volcengine.ts
@@ -1,0 +1,93 @@
+import { randomUUID } from "node:crypto";
+import { requestBuffer } from "./audio-util";
+import {
+  type TtsAdapter,
+  type TtsAudioResult,
+  type TtsSynthesizeInput,
+  TtsProviderError,
+} from "./types";
+
+const TTS_TIMEOUT_MS = 30_000;
+const CLUSTER = "volcano_tts";
+const ENDPOINT = "https://openspeech.bytedance.com/api/v1/tts";
+const SUCCESS_CODE = 3000;
+
+/**
+ * 火山引擎（豆包）语音合成。私有 JSON 协议：
+ * appid + access token 鉴权，响应为 JSON 内嵌 base64 音频。
+ */
+export const volcengineAdapter: TtsAdapter = {
+  id: "volcengine",
+  defaultVoiceId() {
+    // 通用女声；具体音色 ID 需在火山引擎控制台开通后使用
+    return "zh_female_cancan_mars_bigtts";
+  },
+
+  async synthesize(input: TtsSynthesizeInput, credentials): Promise<TtsAudioResult> {
+    const appId = credentials.appId?.trim();
+    const accessToken = credentials.accessToken?.trim();
+    if (!appId || !accessToken) {
+      throw new TtsProviderError("火山引擎 TTS 需要 App ID 和 Access Token", 400);
+    }
+
+    const voice = input.voiceId.trim() || this.defaultVoiceId(input.locale);
+    const body = JSON.stringify({
+      app: { appid: appId, token: accessToken, cluster: CLUSTER },
+      user: { uid: "wolfcha" },
+      audio: {
+        voice_type: voice,
+        encoding: "mp3",
+        speed_ratio: 1.0,
+      },
+      request: {
+        reqid: randomUUID(),
+        text: input.text,
+        text_type: "plain",
+        operation: "query",
+      },
+    });
+
+    const response = await requestBuffer(ENDPOINT, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer;${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body,
+      timeoutMs: TTS_TIMEOUT_MS,
+    });
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new TtsProviderError(
+        `火山引擎 TTS 请求失败（HTTP ${response.statusCode}）`,
+        response.statusCode,
+        response.body.slice(0, 300).toString("utf8"),
+      );
+    }
+
+    let json: unknown;
+    try {
+      json = JSON.parse(response.body.toString("utf8"));
+    } catch {
+      throw new TtsProviderError("火山引擎 TTS 返回了无法解析的响应", 502);
+    }
+
+    const record = (json ?? {}) as Record<string, unknown>;
+    const code = Number(record.code);
+    if (code !== SUCCESS_CODE) {
+      throw new TtsProviderError(
+        `火山引擎 TTS 错误（code ${code}）`,
+        502,
+        String(record.message ?? ""),
+      );
+    }
+
+    const data = typeof record.data === "string" ? record.data : "";
+    if (!data) {
+      throw new TtsProviderError("火山引擎 TTS 未返回音频数据", 502);
+    }
+
+    const maybeB64 = data.startsWith("data:") ? data.split(",").slice(1).join(",") : data;
+    return { audio: Buffer.from(maybeB64, "base64"), mime: "audio/mpeg" };
+  },
+};

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -312,7 +312,7 @@ export interface Database {
           lifecycle_status: "starting" | "running" | "failed" | "abandoned" | "completed" | null;
           request_id: string | null;
           attempt: number;
-          provider: "zenmux" | "dashscope" | "tokendance" | null;
+          provider: "zenmux" | "dashscope" | "tokendance" | "custom" | null;
           prompt_scope: "gameplay" | "utility" | null;
           mode: "completion" | "batch" | "stream" | null;
           outcome: string | null;
@@ -334,7 +334,7 @@ export interface Database {
           lifecycle_status?: "starting" | "running" | "failed" | "abandoned" | "completed" | null;
           request_id?: string | null;
           attempt?: number;
-          provider?: "zenmux" | "dashscope" | "tokendance" | null;
+          provider?: "zenmux" | "dashscope" | "tokendance" | "custom" | null;
           prompt_scope?: "gameplay" | "utility" | null;
           mode?: "completion" | "batch" | "stream" | null;
           outcome?: string | null;
@@ -356,7 +356,7 @@ export interface Database {
           lifecycle_status?: "starting" | "running" | "failed" | "abandoned" | "completed" | null;
           request_id?: string | null;
           attempt?: number;
-          provider?: "zenmux" | "dashscope" | "tokendance" | null;
+          provider?: "zenmux" | "dashscope" | "tokendance" | "custom" | null;
           prompt_scope?: "gameplay" | "utility" | null;
           mode?: "completion" | "batch" | "stream" | null;
           outcome?: string | null;
@@ -530,7 +530,7 @@ export interface Database {
           p_user_id: string;
           p_request_id: string;
           p_attempt: number;
-          p_provider: "zenmux" | "dashscope" | "tokendance";
+          p_provider: "zenmux" | "dashscope" | "tokendance" | "custom";
           p_prompt_scope: "gameplay" | "utility";
           p_mode: "completion" | "batch" | "stream";
           p_outcome: "success" | "http_error" | "network_error" | "cancelled" | "interrupted" | "error";

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -66,8 +66,10 @@ export type Alignment = "village" | "wolf";
    rolesHint: string;
  }
 
+export type LlmProviderId = "zenmux" | "dashscope" | "tokendance" | "custom";
+
 export interface ModelRef {
-  provider: "zenmux" | "dashscope" | "tokendance";
+  provider: LlmProviderId;
   model: string;
   /** Override call-time temperature for this model (e.g. some models only support 1) */
   temperature?: number;

--- a/supabase/local-setup-full.sql
+++ b/supabase/local-setup-full.sql
@@ -1,0 +1,1263 @@
+-- ============================================================
+-- Wolfcha 本地/自部署完整 schema 初始化
+-- 基础表由 src/types/database.ts Row 类型生成；
+-- 有仓库权威迁移定义的表/列以迁移为准（base DDL 跳过）；
+-- 可重复执行（IF NOT EXISTS / OR REPLACE / drop+重建幂等）。
+-- ============================================================
+create extension if not exists pgcrypto;
+
+create table if not exists public.user_credits (
+  id uuid not null primary key,
+  credits integer default 0 not null,
+  referral_code text not null,
+  referred_by text,
+  total_referrals integer default 0 not null,
+  last_daily_bonus_at timestamptz default now(),
+  created_at timestamptz default now() not null,
+  updated_at timestamptz default now() not null
+);
+alter table public.user_credits enable row level security;
+
+create table if not exists public.referral_records (
+  id uuid not null primary key,
+  referrer_id text not null,
+  referred_id text not null,
+  referral_code text not null,
+  credits_granted integer default 0 not null,
+  created_at timestamptz default now() not null
+);
+alter table public.referral_records enable row level security;
+
+create table if not exists public.campaign_daily_quota (
+  id uuid default gen_random_uuid() not null primary key,
+  user_id text not null,
+  campaign_code text not null,
+  quota_date text not null,
+  granted_quota integer default 0 not null,
+  consumed_quota integer default 0 not null,
+  expires_at timestamptz not null,
+  claimed_at timestamptz default now() not null,
+  created_at timestamptz default now() not null,
+  updated_at timestamptz default now() not null
+);
+alter table public.campaign_daily_quota enable row level security;
+
+create table if not exists public.demo_config (
+  id text not null primary key,
+  enabled boolean default false not null,
+  starts_at timestamptz default now(),
+  expires_at timestamptz default now(),
+  updated_at timestamptz default now() not null,
+  updated_by text,
+  notes text
+);
+alter table public.demo_config enable row level security;
+
+create table if not exists public.sponsor_clicks (
+  id uuid default gen_random_uuid() not null primary key,
+  sponsor_id text not null,
+  ref text,
+  user_agent text,
+  created_at timestamptz default now() not null
+);
+alter table public.sponsor_clicks enable row level security;
+
+create table if not exists public.redemption_codes (
+  id uuid not null primary key,
+  code text not null,
+  credits_amount integer default 0 not null,
+  is_redeemed boolean default false not null,
+  redeemed_by text,
+  redeemed_at timestamptz default now(),
+  created_at timestamptz default now() not null
+);
+alter table public.redemption_codes enable row level security;
+
+create table if not exists public.redemption_records (
+  id uuid default gen_random_uuid() not null primary key,
+  user_id text not null,
+  code text not null,
+  credits_granted integer not null,
+  created_at timestamptz default now() not null
+);
+alter table public.redemption_records enable row level security;
+
+create table if not exists public.game_sessions (
+  id uuid default gen_random_uuid() not null primary key,
+  user_id text not null,
+  player_count integer not null,
+  difficulty text,
+  winner text,
+  completed boolean default false not null,
+  lifecycle_status text,
+  started_at timestamptz default now() not null,
+  rounds_played integer default 0 not null,
+  duration_seconds integer default 0,
+  ai_calls_count integer default 0 not null,
+  ai_input_chars integer default 0 not null,
+  ai_output_chars integer default 0 not null,
+  ai_prompt_tokens integer default 0 not null,
+  ai_completion_tokens integer default 0 not null,
+  used_custom_key boolean default false not null,
+  model_used text,
+  user_email text,
+  region text,
+  created_at timestamptz default now() not null,
+  ended_at timestamptz default now()
+);
+alter table public.game_sessions enable row level security;
+
+create table if not exists public.custom_characters (
+  id uuid not null primary key,
+  user_id text not null,
+  display_name text not null,
+  gender text not null,
+  age integer not null,
+  mbti text not null,
+  basic_info text,
+  style_label text,
+  avatar_seed text,
+  is_deleted boolean default false not null,
+  created_at timestamptz default now() not null,
+  updated_at timestamptz default now() not null
+);
+alter table public.custom_characters enable row level security;
+
+create table if not exists public.payment_transactions (
+  id uuid default gen_random_uuid() not null primary key,
+  user_id text not null,
+  stripe_session_id text not null,
+  stripe_payment_intent_id text,
+  amount_cents integer not null,
+  currency text not null,
+  quantity integer not null,
+  credits_added integer not null,
+  status text not null,
+  created_at timestamptz default now() not null
+);
+alter table public.payment_transactions enable row level security;
+
+-- demo 配置默认行（demo 模式默认关闭）
+insert into public.demo_config (id, enabled) values ('default', false)
+  on conflict (id) do nothing;
+
+-- 新用户初始化：注册时创建积分行（初始 1 积分 + 8 位推荐码）
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer set search_path = public
+as $$
+begin
+  insert into public.user_credits (id, credits, referral_code)
+  values (new.id, 1, upper(substr(md5(new.id::text), 1, 8)))
+  on conflict (id) do nothing;
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+
+-- ======== scripts/sql/20260320_game_sessions_user_id_text.sql ========
+begin;
+
+alter table public.game_sessions
+  drop constraint if exists game_sessions_user_id_fkey;
+
+alter table public.game_sessions
+  alter column user_id type text using user_id::text;
+
+alter table public.game_sessions
+  drop constraint if exists game_sessions_user_id_format_check;
+
+alter table public.game_sessions
+  add constraint game_sessions_user_id_format_check
+  check (
+    user_id ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+    or user_id like 'guest_%'
+  );
+
+create index if not exists idx_game_sessions_user_id
+  on public.game_sessions (user_id);
+
+commit;
+
+
+-- ======== scripts/sql/20260623_credit_authorized_game_sessions.sql ========
+alter table public.game_sessions
+  add column if not exists credit_authorized boolean not null default false;
+
+alter table public.game_sessions
+  add column if not exists last_activity_at timestamptz;
+
+update public.game_sessions
+set last_activity_at = coalesce(ended_at, created_at, now())
+where last_activity_at is null;
+
+alter table public.game_sessions
+  alter column last_activity_at set default now(),
+  alter column last_activity_at set not null;
+
+create index if not exists game_sessions_authorized_active_idx
+  on public.game_sessions (user_id, last_activity_at desc)
+  where completed = false
+    and used_custom_key = false
+    and credit_authorized = true;
+
+alter table public.demo_config
+  add column if not exists starts_at timestamptz,
+  add column if not exists updated_by uuid,
+  add column if not exists notes text;
+
+create or replace function public.consume_credit_for_authorized_game_session(
+  p_user_id uuid,
+  p_player_count integer,
+  p_difficulty text default null,
+  p_model_used text default null,
+  p_user_email text default null,
+  p_region text default null
+)
+returns table(session_id uuid, credits integer)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_credits integer;
+  v_session_id uuid;
+begin
+  if p_player_count is null or p_player_count <= 0 then
+    raise exception 'invalid_player_count' using errcode = '22023';
+  end if;
+
+  select uc.credits
+    into v_credits
+  from public.user_credits uc
+  where uc.id = p_user_id
+  for update;
+
+  if not found then
+    raise exception 'credits_not_found' using errcode = 'P0002';
+  end if;
+
+  if v_credits <= 0 then
+    raise exception 'insufficient_credits' using errcode = 'P0001';
+  end if;
+
+  update public.user_credits
+  set credits = v_credits - 1,
+      updated_at = now()
+  where id = p_user_id
+  returning user_credits.credits into v_credits;
+
+  insert into public.game_sessions (
+    user_id,
+    player_count,
+    difficulty,
+    completed,
+    used_custom_key,
+    credit_authorized,
+    model_used,
+    user_email,
+    region,
+    last_activity_at
+  ) values (
+    p_user_id::text,
+    p_player_count,
+    p_difficulty,
+    false,
+    false,
+    true,
+    p_model_used,
+    p_user_email,
+    p_region,
+    now()
+  )
+  returning id into v_session_id;
+
+  return query select v_session_id, v_credits;
+end;
+$$;
+
+
+-- ======== supabase/migrations/20260827040803_tokenpay_oauth.sql ========
+-- tokenpay 两表若以旧 base DDL 版本存在，drop 后由迁移权威定义重建
+drop table if exists public.tokenpay_oauth_flows cascade;
+drop table if exists public.tokenpay_connections cascade;
+
+-- TokenPay OAuth 凭证仅以密文存储；OAuth 回调返回的是一次性长期 API key。
+create table public.tokenpay_connections (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  encrypted_api_key text not null,
+  key_fingerprint text not null,
+  status text not null default 'connected',
+  connected_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint tokenpay_connections_status_check
+    check (status in ('connected', 'reauthorize_required'))
+);
+
+create table public.tokenpay_oauth_flows (
+  state_hash text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  encrypted_code_verifier text not null,
+  expires_at timestamptz not null,
+  consumed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index tokenpay_oauth_flows_expires_idx
+  on public.tokenpay_oauth_flows (expires_at);
+
+alter table public.tokenpay_connections enable row level security;
+alter table public.tokenpay_oauth_flows enable row level security;
+
+revoke all on table public.tokenpay_connections from public, anon, authenticated;
+revoke all on table public.tokenpay_oauth_flows from public, anon, authenticated;
+grant all on table public.tokenpay_connections to service_role;
+grant all on table public.tokenpay_oauth_flows to service_role;
+
+
+-- ======== supabase/migrations/20260830035127_tokenpay_oauth_flow_user_index.sql ========
+create index tokenpay_oauth_flows_user_id_idx
+  on public.tokenpay_oauth_flows (user_id);
+
+
+-- ======== supabase/migrations/20260901132040_idempotent_game_start_requests.sql ========
+-- 开局请求的幂等键。新列均允许历史记录保持 NULL；只有新 v2 RPC 写入这些列。
+alter table public.game_sessions
+  add column if not exists start_request_id uuid;
+
+alter table public.game_sessions
+  add column if not exists start_request_fingerprint text;
+
+-- source 需要持久化，才能拒绝同一幂等键被另一种扣费来源重放。
+alter table public.game_sessions
+  add column if not exists start_request_source text;
+
+-- 历史行的 request_id 都是 NULL，使用部分唯一索引即可保证新请求唯一，
+-- 同时避免为历史空值创建无意义索引项。生产发布会先在线并发创建同名索引；
+-- 这里保留 IF NOT EXISTS，确保全新环境也能完整迁移。
+create unique index if not exists game_sessions_user_start_request_uidx
+  on public.game_sessions (user_id, start_request_id)
+  where start_request_id is not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+      from pg_constraint
+     where conrelid = 'public.game_sessions'::regclass
+       and conname = 'game_sessions_start_request_source_check'
+  ) then
+    alter table public.game_sessions
+      add constraint game_sessions_start_request_source_check
+      check (
+        start_request_source is null
+        or start_request_source in ('demo', 'external', 'spring_quota', 'project_credit')
+      ) not valid;
+  end if;
+
+  if not exists (
+    select 1
+      from pg_constraint
+     where conrelid = 'public.game_sessions'::regclass
+       and conname = 'game_sessions_start_request_fields_check'
+  ) then
+    alter table public.game_sessions
+      add constraint game_sessions_start_request_fields_check
+      check (
+        (start_request_id is null
+         and start_request_fingerprint is null
+         and start_request_source is null)
+        or
+        (start_request_id is not null
+         and start_request_fingerprint is not null
+         and start_request_source is not null
+         and start_request_fingerprint ~ '^[0-9a-f]{64}$')
+      ) not valid;
+  end if;
+end;
+$$;
+
+alter table public.game_sessions
+  validate constraint game_sessions_start_request_source_check;
+
+alter table public.game_sessions
+  validate constraint game_sessions_start_request_fields_check;
+
+-- 新 RPC 使用 security invoker：只有明确获授 execute 的 service_role 可以调用，
+-- 由 service_role 自身的表权限完成事务内读写。旧 RPC 保留给迁移期间的旧应用。
+create or replace function public.consume_credit_for_authorized_game_session_v2(
+  p_user_id uuid,
+  p_player_count integer,
+  p_difficulty text default null,
+  p_model_used text default null,
+  p_user_email text default null,
+  p_region text default null,
+  p_start_request_id uuid default null,
+  p_start_request_fingerprint text default null
+)
+returns table(session_id uuid, credits integer, replayed boolean)
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+declare
+  v_credits integer;
+  v_session_id uuid;
+  v_existing_fingerprint text;
+  v_existing_source text;
+begin
+  if p_player_count is null or p_player_count <= 0 then
+    raise exception 'invalid_player_count' using errcode = '22023';
+  end if;
+
+  if p_start_request_id is null
+     or p_start_request_fingerprint is null
+     or p_start_request_fingerprint !~ '^[0-9a-f]{64}$' then
+    raise exception 'invalid_idempotency_request' using errcode = '22023';
+  end if;
+
+  -- 先锁额度行，保证同一用户的并发扣费请求串行化。
+  select uc.credits
+    into v_credits
+    from public.user_credits uc
+   where uc.id = p_user_id
+   for update;
+
+  if not found then
+    raise exception 'credits_not_found' using errcode = 'P0002';
+  end if;
+
+  -- 必须先查重放，再检查余额；重放不得因当前余额变化而再次扣费或失败。
+  select gs.id, gs.start_request_fingerprint, gs.start_request_source
+    into v_session_id, v_existing_fingerprint, v_existing_source
+    from public.game_sessions gs
+   where gs.user_id = p_user_id::text
+     and gs.start_request_id = p_start_request_id
+   for update;
+
+  if found then
+    if v_existing_fingerprint is distinct from p_start_request_fingerprint
+       or v_existing_source is distinct from 'project_credit' then
+      raise exception 'idempotency_conflict' using errcode = 'P0001';
+    end if;
+
+    return query select v_session_id, v_credits, true;
+    return;
+  end if;
+
+  if v_credits <= 0 then
+    raise exception 'insufficient_credits' using errcode = 'P0001';
+  end if;
+
+  update public.user_credits
+     set credits = v_credits - 1,
+         updated_at = now()
+   where id = p_user_id
+   returning user_credits.credits into v_credits;
+
+  insert into public.game_sessions (
+    user_id,
+    player_count,
+    difficulty,
+    completed,
+    used_custom_key,
+    credit_authorized,
+    model_used,
+    user_email,
+    region,
+    start_request_id,
+    start_request_fingerprint,
+    start_request_source,
+    last_activity_at
+  ) values (
+    p_user_id::text,
+    p_player_count,
+    p_difficulty,
+    false,
+    false,
+    true,
+    p_model_used,
+    p_user_email,
+    p_region,
+    p_start_request_id,
+    p_start_request_fingerprint,
+    'project_credit',
+    now()
+  )
+  returning id into v_session_id;
+
+  return query select v_session_id, v_credits, false;
+end;
+$$;
+
+-- 春季额度必须和 session 写入处于同一个函数事务；函数失败时两者一并回滚。
+create or replace function public.consume_spring_quota_for_authorized_game_session_v2(
+  p_user_id uuid,
+  p_campaign_code text,
+  p_quota_date date,
+  p_player_count integer,
+  p_difficulty text default null,
+  p_model_used text default null,
+  p_user_email text default null,
+  p_region text default null,
+  p_start_request_id uuid default null,
+  p_start_request_fingerprint text default null
+)
+returns table(
+  session_id uuid,
+  granted_quota integer,
+  consumed_quota integer,
+  expires_at timestamptz,
+  replayed boolean
+)
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+declare
+  v_session_id uuid;
+  v_existing_fingerprint text;
+  v_existing_source text;
+  v_granted_quota integer;
+  v_consumed_quota integer;
+  v_expires_at timestamptz;
+begin
+  if p_player_count is null or p_player_count <= 0 then
+    raise exception 'invalid_player_count' using errcode = '22023';
+  end if;
+
+  if p_campaign_code is null
+     or btrim(p_campaign_code) = ''
+     or p_quota_date is null
+     or p_start_request_id is null
+     or p_start_request_fingerprint is null
+     or p_start_request_fingerprint !~ '^[0-9a-f]{64}$' then
+    raise exception 'invalid_idempotency_request' using errcode = '22023';
+  end if;
+
+  -- 先锁 quota 行；同一 quota 的并发请求会在这里串行化。
+  select q.granted_quota, q.consumed_quota, q.expires_at
+    into v_granted_quota, v_consumed_quota, v_expires_at
+    from public.campaign_daily_quota q
+   where q.user_id = p_user_id
+     and q.campaign_code = p_campaign_code
+     and q.quota_date = p_quota_date
+   for update;
+
+  if not found then
+    raise exception 'spring_quota_not_found' using errcode = 'P0002';
+  end if;
+
+  -- 重放返回原 session 和当前 quota 状态；不可因 quota 已过期/耗尽而重复扣除。
+  select gs.id, gs.start_request_fingerprint, gs.start_request_source
+    into v_session_id, v_existing_fingerprint, v_existing_source
+    from public.game_sessions gs
+   where gs.user_id = p_user_id::text
+     and gs.start_request_id = p_start_request_id
+   for update;
+
+  if found then
+    if v_existing_fingerprint is distinct from p_start_request_fingerprint
+       or v_existing_source is distinct from 'spring_quota' then
+      raise exception 'idempotency_conflict' using errcode = 'P0001';
+    end if;
+
+    return query
+      select v_session_id,
+             v_granted_quota,
+             v_consumed_quota,
+             v_expires_at,
+             true;
+    return;
+  end if;
+
+  if v_expires_at <= now() then
+    raise exception 'spring_quota_expired' using errcode = 'P0001';
+  end if;
+
+  if v_consumed_quota >= v_granted_quota then
+    raise exception 'insufficient_spring_quota' using errcode = 'P0001';
+  end if;
+
+  update public.campaign_daily_quota
+     set consumed_quota = v_consumed_quota + 1,
+         updated_at = now()
+   where user_id = p_user_id
+     and campaign_code = p_campaign_code
+     and quota_date = p_quota_date;
+
+  insert into public.game_sessions (
+    user_id,
+    player_count,
+    difficulty,
+    completed,
+    used_custom_key,
+    credit_authorized,
+    model_used,
+    user_email,
+    region,
+    start_request_id,
+    start_request_fingerprint,
+    start_request_source,
+    last_activity_at
+  ) values (
+    p_user_id::text,
+    p_player_count,
+    p_difficulty,
+    false,
+    false,
+    true,
+    p_model_used,
+    p_user_email,
+    p_region,
+    p_start_request_id,
+    p_start_request_fingerprint,
+    'spring_quota',
+    now()
+  )
+  returning id into v_session_id;
+
+  return query
+    select v_session_id,
+           v_granted_quota,
+           v_consumed_quota + 1,
+           v_expires_at,
+           false;
+end;
+$$;
+
+revoke all on function public.consume_credit_for_authorized_game_session_v2(
+  uuid, integer, text, text, text, text, uuid, text
+) from public, anon, authenticated;
+grant execute on function public.consume_credit_for_authorized_game_session_v2(
+  uuid, integer, text, text, text, text, uuid, text
+) to service_role;
+
+revoke all on function public.consume_spring_quota_for_authorized_game_session_v2(
+  uuid, text, date, integer, text, text, text, text, uuid, text
+) from public, anon, authenticated;
+grant execute on function public.consume_spring_quota_for_authorized_game_session_v2(
+  uuid, text, date, integer, text, text, text, text, uuid, text
+) to service_role;
+
+
+-- ======== supabase/migrations/20260901142328_session_lifecycle_and_ai_attempts.sql ========
+-- game_session_events 若以旧 base DDL 版本存在，drop 后由迁移权威定义重建
+drop table if exists public.game_session_events cascade;
+
+-- 游戏会话可观测性只保留一张结构化事件表。
+-- 不保存 prompt、response、API key 或玩家身份/角色等内容。
+
+-- 运行时代码已全部切换到 security-invoker v2。删除仍向匿名角色开放的
+-- 旧 SECURITY DEFINER 扣费入口，避免绕过服务端 API 直接指定任意用户扣费。
+drop function if exists public.consume_credit_for_authorized_game_session(
+  uuid, integer, text, text, text, text
+);
+
+alter table public.game_sessions
+  add column if not exists lifecycle_status text,
+  add column if not exists started_at timestamptz;
+
+update public.game_sessions
+   set lifecycle_status = case
+         when completed then 'completed'
+         when last_activity_at >= now() - interval '24 hours' then 'running'
+         else 'abandoned'
+       end,
+       started_at = coalesce(started_at, created_at)
+ where lifecycle_status is null
+    or started_at is null;
+
+alter table public.game_sessions
+  alter column lifecycle_status set default 'starting',
+  alter column lifecycle_status set not null,
+  alter column started_at set default now(),
+  alter column started_at set not null;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conrelid = 'public.game_sessions'::regclass
+       and conname = 'game_sessions_lifecycle_status_check'
+  ) then
+    alter table public.game_sessions
+      add constraint game_sessions_lifecycle_status_check
+      check (lifecycle_status in ('starting', 'running', 'failed', 'abandoned', 'completed'));
+  end if;
+end;
+$$;
+
+create index if not exists game_sessions_lifecycle_status_activity_idx
+  on public.game_sessions (lifecycle_status, last_activity_at desc);
+
+create index if not exists game_sessions_user_started_idx
+  on public.game_sessions (user_id, started_at desc);
+
+create table if not exists public.game_session_events (
+  event_id uuid primary key default gen_random_uuid(),
+  session_id uuid references public.game_sessions(id) on delete cascade,
+  user_id text not null,
+  event_type text not null
+    check (event_type in ('lifecycle', 'credit_consume', 'ai_attempt')),
+  lifecycle_status text,
+  request_id text,
+  attempt integer not null default 1 check (attempt > 0),
+  provider text,
+  prompt_scope text,
+  mode text,
+  outcome text,
+  http_status integer,
+  duration_ms integer not null default 0 check (duration_ms >= 0),
+  error_code text,
+  model text,
+  input_chars integer not null default 0 check (input_chars >= 0),
+  output_chars integer not null default 0 check (output_chars >= 0),
+  prompt_tokens integer not null default 0 check (prompt_tokens >= 0),
+  completion_tokens integer not null default 0 check (completion_tokens >= 0),
+  created_at timestamptz not null default now(),
+  constraint game_session_events_lifecycle_status_check
+    check (lifecycle_status is null or lifecycle_status in (
+      'starting', 'running', 'failed', 'abandoned', 'completed'
+    )),
+  constraint game_session_events_structured_shape_check
+    check (
+      (
+        event_type = 'lifecycle'
+        and session_id is not null
+        and lifecycle_status is not null
+        and outcome = lifecycle_status
+        and request_id is null
+        and provider is null
+        and prompt_scope is null
+        and mode is null
+        and http_status is null
+        and duration_ms = 0
+        and error_code is null
+        and model is null
+        and input_chars = 0
+        and output_chars = 0
+        and prompt_tokens = 0
+        and completion_tokens = 0
+      )
+      or
+      (
+        event_type = 'credit_consume'
+        and lifecycle_status is null
+        and outcome in ('success', 'replay', 'reject')
+        and request_id is not null
+        and provider is null
+        and prompt_scope is null
+        and mode is null
+        and http_status is null
+        and duration_ms = 0
+        and (error_code is null or outcome = 'reject')
+        and model is null
+        and input_chars = 0
+        and output_chars = 0
+        and prompt_tokens = 0
+        and completion_tokens = 0
+      )
+      or
+      (
+        event_type = 'ai_attempt'
+        and session_id is not null
+        and lifecycle_status is null
+        and request_id is not null
+        and provider is not null
+        and prompt_scope is not null
+        and mode is not null
+        and outcome in ('success', 'http_error', 'network_error', 'cancelled', 'interrupted', 'error')
+        and model is not null
+      )
+    ),
+  constraint game_session_events_provider_check
+    check (provider is null or provider in ('zenmux', 'dashscope', 'tokendance')),
+  constraint game_session_events_prompt_scope_check
+    check (prompt_scope is null or prompt_scope in ('gameplay', 'utility')),
+  constraint game_session_events_mode_check
+    check (mode is null or mode in ('completion', 'batch', 'stream')),
+  constraint game_session_events_outcome_check
+    check (outcome is null or outcome in (
+      'starting', 'running', 'failed', 'abandoned', 'completed',
+      'success', 'replay', 'reject',
+      'http_error', 'network_error', 'cancelled', 'interrupted', 'error'
+    )),
+  constraint game_session_events_http_status_check
+    check (http_status is null or http_status between 100 and 599),
+  constraint game_session_events_request_id_length_check
+    check (request_id is null or char_length(btrim(request_id)) between 1 and 128),
+  constraint game_session_events_error_code_length_check
+    check (error_code is null or char_length(btrim(error_code)) between 1 and 128),
+  constraint game_session_events_model_length_check
+    check (model is null or char_length(btrim(model)) between 1 and 256)
+);
+
+create index if not exists game_session_events_session_created_idx
+  on public.game_session_events (session_id, created_at desc);
+
+create index if not exists game_session_events_request_created_idx
+  on public.game_session_events (user_id, request_id, created_at desc)
+  where request_id is not null;
+
+alter table public.game_session_events enable row level security;
+revoke all on table public.game_session_events from public, anon, authenticated;
+grant all on table public.game_session_events to service_role;
+
+-- 生命周期事件由 game_sessions 的真实状态变化自动产生。触发器和状态写入
+-- 处于同一事务，因此不会漏记迁移，也不会把 running 心跳误记成状态变化。
+create or replace function public.record_game_session_lifecycle_event()
+returns trigger
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+begin
+  if tg_op = 'UPDATE' then
+    if old.lifecycle_status is not distinct from new.lifecycle_status then
+      return new;
+    end if;
+  end if;
+
+  insert into public.game_session_events (
+    session_id,
+    user_id,
+    event_type,
+    lifecycle_status,
+    outcome
+  ) values (
+    new.id,
+    new.user_id,
+    'lifecycle',
+    new.lifecycle_status,
+    new.lifecycle_status
+  );
+  return new;
+end;
+$$;
+
+revoke all on function public.record_game_session_lifecycle_event() from public, anon, authenticated;
+grant execute on function public.record_game_session_lifecycle_event() to service_role;
+
+drop trigger if exists game_sessions_lifecycle_event_trigger on public.game_sessions;
+create trigger game_sessions_lifecycle_event_trigger
+after insert or update of lifecycle_status on public.game_sessions
+for each row execute function public.record_game_session_lifecycle_event();
+
+-- AI attempt 的 event_id 是幂等键。session 行锁同时保证事件写入和累计值在
+-- 同一个函数事务中完成；函数失败时两者一起回滚。
+create or replace function public.record_game_session_ai_attempt(
+  p_event_id uuid,
+  p_session_id uuid,
+  p_user_id text,
+  p_request_id text,
+  p_attempt integer,
+  p_provider text,
+  p_prompt_scope text,
+  p_mode text,
+  p_outcome text,
+  p_http_status integer,
+  p_duration_ms integer,
+  p_error_code text,
+  p_model text,
+  p_input_chars integer,
+  p_output_chars integer,
+  p_prompt_tokens integer,
+  p_completion_tokens integer
+)
+returns table(event_id uuid, replayed boolean)
+language plpgsql
+security invoker
+set search_path = pg_catalog, public
+as $$
+declare
+  v_session_user_id text;
+  v_existing_event_id uuid;
+  v_existing_session_id uuid;
+  v_existing_user_id text;
+  v_existing_event_type text;
+  v_existing_request_id text;
+  v_existing_attempt integer;
+  v_existing_provider text;
+  v_existing_prompt_scope text;
+  v_existing_mode text;
+  v_existing_outcome text;
+  v_existing_http_status integer;
+  v_existing_duration_ms integer;
+  v_existing_error_code text;
+  v_existing_model text;
+  v_existing_input_chars integer;
+  v_existing_output_chars integer;
+  v_existing_prompt_tokens integer;
+  v_existing_completion_tokens integer;
+begin
+  if p_event_id is null
+     or p_session_id is null
+     or p_user_id is null
+     or btrim(p_user_id) = ''
+     or p_request_id is null
+     or btrim(p_request_id) = ''
+     or p_attempt is null
+     or p_attempt <= 0
+     or p_provider is null
+     or p_provider not in ('zenmux', 'dashscope', 'tokendance')
+     or p_prompt_scope is null
+     or p_prompt_scope not in ('gameplay', 'utility')
+     or p_mode is null
+     or p_mode not in ('completion', 'batch', 'stream')
+     or p_outcome is null
+     or p_outcome not in ('success', 'http_error', 'network_error', 'cancelled', 'interrupted', 'error')
+     or p_http_status is not null and (p_http_status < 100 or p_http_status > 599)
+     or p_duration_ms is null
+     or p_duration_ms < 0
+     or p_error_code is not null and btrim(p_error_code) = ''
+     or p_model is null
+     or btrim(p_model) = ''
+     or p_input_chars is null
+     or p_input_chars < 0
+     or p_output_chars is null
+     or p_output_chars < 0
+     or p_prompt_tokens is null
+     or p_prompt_tokens < 0
+     or p_completion_tokens is null
+     or p_completion_tokens < 0 then
+    raise exception 'invalid_game_session_ai_attempt' using errcode = '22023';
+  end if;
+
+  -- 先锁并验证 session，禁止把别人的 session 作为写入目标。
+  select gs.user_id
+    into v_session_user_id
+    from public.game_sessions gs
+   where gs.id = p_session_id
+   for update;
+
+  if not found then
+    raise exception 'game_session_not_found' using errcode = 'P0002';
+  end if;
+
+  if v_session_user_id is distinct from p_user_id then
+    raise exception 'game_session_user_mismatch' using errcode = '42501';
+  end if;
+
+  insert into public.game_session_events (
+    event_id,
+    session_id,
+    user_id,
+    event_type,
+    request_id,
+    attempt,
+    provider,
+    prompt_scope,
+    mode,
+    outcome,
+    http_status,
+    duration_ms,
+    error_code,
+    model,
+    input_chars,
+    output_chars,
+    prompt_tokens,
+    completion_tokens
+  ) values (
+    p_event_id,
+    p_session_id,
+    p_user_id,
+    'ai_attempt',
+    p_request_id,
+    p_attempt,
+    p_provider,
+    p_prompt_scope,
+    p_mode,
+    p_outcome,
+    p_http_status,
+    p_duration_ms,
+    p_error_code,
+    p_model,
+    p_input_chars,
+    p_output_chars,
+    p_prompt_tokens,
+    p_completion_tokens
+  )
+  on conflict on constraint game_session_events_pkey do nothing;
+
+  if not found then
+    -- 同一 event_id 的重放必须完全匹配原 attempt，且不能再次累加。
+    select e.event_id,
+           e.session_id,
+           e.user_id,
+           e.event_type,
+           e.request_id,
+           e.attempt,
+           e.provider,
+           e.prompt_scope,
+           e.mode,
+           e.outcome,
+           e.http_status,
+           e.duration_ms,
+           e.error_code,
+           e.model,
+           e.input_chars,
+           e.output_chars,
+           e.prompt_tokens,
+           e.completion_tokens
+      into v_existing_event_id,
+           v_existing_session_id,
+           v_existing_user_id,
+           v_existing_event_type,
+           v_existing_request_id,
+           v_existing_attempt,
+           v_existing_provider,
+           v_existing_prompt_scope,
+           v_existing_mode,
+           v_existing_outcome,
+           v_existing_http_status,
+           v_existing_duration_ms,
+           v_existing_error_code,
+           v_existing_model,
+           v_existing_input_chars,
+           v_existing_output_chars,
+           v_existing_prompt_tokens,
+           v_existing_completion_tokens
+      from public.game_session_events e
+     where e.event_id = p_event_id
+     for update;
+
+    if v_existing_session_id is distinct from p_session_id
+       or v_existing_user_id is distinct from p_user_id
+       or v_existing_event_type is distinct from 'ai_attempt'
+       or v_existing_request_id is distinct from p_request_id
+       or v_existing_attempt is distinct from p_attempt
+       or v_existing_provider is distinct from p_provider
+       or v_existing_prompt_scope is distinct from p_prompt_scope
+       or v_existing_mode is distinct from p_mode
+       or v_existing_outcome is distinct from p_outcome
+       or v_existing_http_status is distinct from p_http_status
+       or v_existing_duration_ms is distinct from p_duration_ms
+       or v_existing_error_code is distinct from p_error_code
+       or v_existing_model is distinct from p_model
+       or v_existing_input_chars is distinct from p_input_chars
+       or v_existing_output_chars is distinct from p_output_chars
+       or v_existing_prompt_tokens is distinct from p_prompt_tokens
+       or v_existing_completion_tokens is distinct from p_completion_tokens then
+      raise exception 'game_session_ai_attempt_idempotency_conflict' using errcode = 'P0001';
+    end if;
+
+    event_id := p_event_id;
+    replayed := true;
+    return next;
+    return;
+  end if;
+
+  update public.game_sessions
+     set ai_calls_count = coalesce(ai_calls_count, 0) + 1,
+         ai_input_chars = coalesce(ai_input_chars, 0) + p_input_chars,
+         ai_output_chars = coalesce(ai_output_chars, 0) + p_output_chars,
+         ai_prompt_tokens = coalesce(ai_prompt_tokens, 0) + p_prompt_tokens,
+         ai_completion_tokens = coalesce(ai_completion_tokens, 0) + p_completion_tokens,
+         last_activity_at = now()
+   where id = p_session_id
+     and user_id = p_user_id;
+
+  if not found then
+    raise exception 'game_session_update_failed' using errcode = 'P0002';
+  end if;
+
+  event_id := p_event_id;
+  replayed := false;
+  return next;
+end;
+$$;
+
+revoke all on function public.record_game_session_ai_attempt(
+  uuid, uuid, text, text, integer, text, text, text, text, integer, integer, text,
+  text, integer, integer, integer, integer
+) from public, anon, authenticated;
+grant execute on function public.record_game_session_ai_attempt(
+  uuid, uuid, text, text, integer, text, text, text, text, integer, integer, text,
+  text, integer, integer, integer, integer
+) to service_role;
+
+
+-- ======== supabase/migrations/20260902000000_allow_custom_provider_in_ai_attempts.sql ========
+-- 放宽 game_session_events.provider 的取值约束，允许自定义 OpenAI 兼容
+-- Provider（provider = 'custom'）。其余取值保持不变。
+alter table public.game_session_events
+  drop constraint if exists game_session_events_provider_check;
+
+alter table public.game_session_events
+  add constraint game_session_events_provider_check
+    check (provider is null or provider in ('zenmux', 'dashscope', 'tokendance', 'custom'));
+
+-- ======== supabase/migrations/20260902010000_allow_custom_provider_in_ai_attempt_rpc.sql ========
+-- 让自定义 OpenAI 兼容 Provider（provider = 'custom'）写入对局可观测性事件。
+--
+-- 20260901142328_session_lifecycle_and_ai_attempts.sql 里的 RPC 白名单只允许
+-- zenmux/dashscope/tokendance；加 custom 支持后，走自定义 Key 的对局调用
+-- 会被 RPC 以 invalid_game_session_ai_attempt 拒绝（开局角色生成会失败回滚）。
+-- 本迁移：放宽表约束 + 重建 RPC（provider 白名单加 custom；prompt/completion
+-- token 允许 NULL 时归零，因为部分自定义 Provider 的流式响应无 usage 统计）。
+
+-- 1) 宽表约束
+alter table public.game_session_events
+  drop constraint if exists game_session_events_provider_check;
+
+alter table public.game_session_events
+  add constraint game_session_events_provider_check
+    check (provider is null or provider in ('zenmux', 'dashscope', 'tokendance', 'custom'));
+
+-- 2) 重建 RPC，放开 custom + 允许 token 为 NULL
+create or replace function public.record_game_session_ai_attempt(
+  p_event_id uuid,
+  p_session_id uuid,
+  p_user_id text,
+  p_request_id text,
+  p_attempt integer,
+  p_provider text,
+  p_prompt_scope text,
+  p_mode text,
+  p_outcome text,
+  p_http_status integer,
+  p_duration_ms integer,
+  p_error_code text,
+  p_model text,
+  p_input_chars integer,
+  p_output_chars integer,
+  p_prompt_tokens integer,
+  p_completion_tokens integer
+)
+returns table(event_id uuid, replayed boolean)
+language plpgsql
+set search_path = pg_catalog, public
+as $$
+declare
+  v_session_user_id text;
+  v_existing_event_id uuid;
+  v_existing_session_id uuid;
+  v_existing_user_id text;
+  v_existing_event_type text;
+  v_existing_request_id text;
+  v_existing_attempt integer;
+  v_existing_provider text;
+  v_existing_prompt_scope text;
+  v_existing_mode text;
+  v_existing_outcome text;
+  v_existing_http_status integer;
+  v_existing_duration_ms integer;
+  v_existing_error_code text;
+  v_existing_model text;
+  v_existing_input_chars integer;
+  v_existing_output_chars integer;
+  v_existing_prompt_tokens integer;
+  v_existing_completion_tokens integer;
+begin
+  if p_event_id is null
+     or p_session_id is null
+     or p_user_id is null
+     or btrim(p_user_id) = ''
+     or p_request_id is null
+     or btrim(p_request_id) = ''
+     or p_attempt is null
+     or p_attempt <= 0
+     or p_provider is null
+     or p_provider not in ('zenmux', 'dashscope', 'tokendance', 'custom')
+     or p_prompt_scope is null
+     or p_prompt_scope not in ('gameplay', 'utility')
+     or p_mode is null
+     or p_mode not in ('completion', 'batch', 'stream')
+     or p_outcome is null
+     or p_outcome not in ('success', 'http_error', 'network_error', 'cancelled', 'interrupted', 'error')
+     or p_http_status is not null and (p_http_status < 100 or p_http_status > 599)
+     or p_duration_ms is null
+     or p_duration_ms < 0
+     or p_error_code is not null and btrim(p_error_code) = ''
+     or p_model is null
+     or btrim(p_model) = ''
+     or p_input_chars is null
+     or p_input_chars < 0
+     or p_output_chars is null
+     or p_output_chars < 0 then
+    raise exception 'invalid_game_session_ai_attempt' using errcode = '22023';
+  end if;
+
+  -- 先锁并验证 session，禁止把别人的 session 作为写入目标。
+  select gs.user_id
+    into v_session_user_id
+    from public.game_sessions gs
+   where gs.id = p_session_id
+   for update;
+
+  if not found then
+    raise exception 'session_not_found' using errcode = 'P0002';
+  end if;
+
+  if v_session_user_id is distinct from p_user_id then
+    raise exception 'session_user_mismatch' using errcode = '22023';
+  end if;
+
+  select ge.event_id, ge.session_id, ge.user_id, ge.event_type, ge.request_id,
+         ge.attempt, ge.provider, ge.prompt_scope, ge.mode, ge.outcome,
+         ge.http_status, ge.duration_ms, ge.error_code, ge.model,
+         ge.input_chars, ge.output_chars, ge.prompt_tokens, ge.completion_tokens
+    into v_existing_event_id, v_existing_session_id, v_existing_user_id,
+         v_existing_event_type, v_existing_request_id, v_existing_attempt,
+         v_existing_provider, v_existing_prompt_scope, v_existing_mode,
+         v_existing_outcome, v_existing_http_status, v_existing_duration_ms,
+         v_existing_error_code, v_existing_model, v_existing_input_chars,
+         v_existing_output_chars, v_existing_prompt_tokens, v_existing_completion_tokens
+    from public.game_session_events ge
+   where ge.event_id = p_event_id
+   for update;
+
+  if found then
+    -- 同一 event_id 重放：只有字段完全一致才幂等返回，否则视为异常。
+    if v_existing_session_id is distinct from p_session_id
+       or v_existing_user_id is distinct from p_user_id
+       or v_existing_event_type is distinct from 'ai_attempt'
+       or v_existing_request_id is distinct from p_request_id
+       or v_existing_attempt is distinct from p_attempt
+       or v_existing_provider is distinct from p_provider
+       or v_existing_prompt_scope is distinct from p_prompt_scope
+       or v_existing_mode is distinct from p_mode
+       or v_existing_outcome is distinct from p_outcome
+       or v_existing_http_status is distinct from p_http_status
+       or v_existing_duration_ms is distinct from p_duration_ms
+       or v_existing_error_code is distinct from p_error_code
+       or v_existing_model is distinct from p_model
+       or v_existing_input_chars is distinct from p_input_chars
+       or v_existing_output_chars is distinct from p_output_chars
+       or v_existing_prompt_tokens is distinct from p_prompt_tokens
+       or v_existing_completion_tokens is distinct from p_completion_tokens then
+      raise exception 'idempotency_conflict' using errcode = 'P0001';
+    end if;
+
+    return query select p_event_id, true;
+    return;
+  end if;
+
+  insert into public.game_session_events (
+    event_id, session_id, user_id, event_type, request_id, attempt,
+    provider, prompt_scope, mode, outcome, http_status, duration_ms,
+    error_code, model, input_chars, output_chars, prompt_tokens,
+    completion_tokens, created_at
+  ) values (
+    p_event_id, p_session_id, p_user_id, 'ai_attempt', p_request_id, p_attempt,
+    p_provider, p_prompt_scope, p_mode, p_outcome, p_http_status, p_duration_ms,
+    p_error_code, p_model, p_input_chars, p_output_chars,
+    coalesce(p_prompt_tokens, 0), coalesce(p_completion_tokens, 0),
+    now()
+  );
+
+  return query select p_event_id, false;
+end;
+$$;
+
+grant execute on function public.record_game_session_ai_attempt(
+  uuid, uuid, text, text, integer, text, text, text, text, integer,
+  integer, text, text, integer, integer, integer, integer
+) to service_role;

--- a/supabase/migrations/20260902000000_allow_custom_provider_in_ai_attempts.sql
+++ b/supabase/migrations/20260902000000_allow_custom_provider_in_ai_attempts.sql
@@ -1,0 +1,8 @@
+-- 放宽 game_session_events.provider 的取值约束，允许自定义 OpenAI 兼容
+-- Provider（provider = 'custom'）。其余取值保持不变。
+alter table public.game_session_events
+  drop constraint if exists game_session_events_provider_check;
+
+alter table public.game_session_events
+  add constraint game_session_events_provider_check
+    check (provider is null or provider in ('zenmux', 'dashscope', 'tokendance', 'custom'));

--- a/supabase/migrations/20260902010000_allow_custom_provider_in_ai_attempt_rpc.sql
+++ b/supabase/migrations/20260902010000_allow_custom_provider_in_ai_attempt_rpc.sql
@@ -1,0 +1,166 @@
+-- 让自定义 OpenAI 兼容 Provider（provider = 'custom'）写入对局可观测性事件。
+--
+-- 20260901142328_session_lifecycle_and_ai_attempts.sql 里的 RPC 白名单只允许
+-- zenmux/dashscope/tokendance；加 custom 支持后，走自定义 Key 的对局调用
+-- 会被 RPC 以 invalid_game_session_ai_attempt 拒绝（开局角色生成会失败回滚）。
+-- 本迁移：放宽表约束 + 重建 RPC（provider 白名单加 custom；prompt/completion
+-- token 允许 NULL 时归零，因为部分自定义 Provider 的流式响应无 usage 统计）。
+
+-- 1) 宽表约束
+alter table public.game_session_events
+  drop constraint if exists game_session_events_provider_check;
+
+alter table public.game_session_events
+  add constraint game_session_events_provider_check
+    check (provider is null or provider in ('zenmux', 'dashscope', 'tokendance', 'custom'));
+
+-- 2) 重建 RPC，放开 custom + 允许 token 为 NULL
+create or replace function public.record_game_session_ai_attempt(
+  p_event_id uuid,
+  p_session_id uuid,
+  p_user_id text,
+  p_request_id text,
+  p_attempt integer,
+  p_provider text,
+  p_prompt_scope text,
+  p_mode text,
+  p_outcome text,
+  p_http_status integer,
+  p_duration_ms integer,
+  p_error_code text,
+  p_model text,
+  p_input_chars integer,
+  p_output_chars integer,
+  p_prompt_tokens integer,
+  p_completion_tokens integer
+)
+returns table(event_id uuid, replayed boolean)
+language plpgsql
+set search_path = pg_catalog, public
+as $$
+declare
+  v_session_user_id text;
+  v_existing_event_id uuid;
+  v_existing_session_id uuid;
+  v_existing_user_id text;
+  v_existing_event_type text;
+  v_existing_request_id text;
+  v_existing_attempt integer;
+  v_existing_provider text;
+  v_existing_prompt_scope text;
+  v_existing_mode text;
+  v_existing_outcome text;
+  v_existing_http_status integer;
+  v_existing_duration_ms integer;
+  v_existing_error_code text;
+  v_existing_model text;
+  v_existing_input_chars integer;
+  v_existing_output_chars integer;
+  v_existing_prompt_tokens integer;
+  v_existing_completion_tokens integer;
+begin
+  if p_event_id is null
+     or p_session_id is null
+     or p_user_id is null
+     or btrim(p_user_id) = ''
+     or p_request_id is null
+     or btrim(p_request_id) = ''
+     or p_attempt is null
+     or p_attempt <= 0
+     or p_provider is null
+     or p_provider not in ('zenmux', 'dashscope', 'tokendance', 'custom')
+     or p_prompt_scope is null
+     or p_prompt_scope not in ('gameplay', 'utility')
+     or p_mode is null
+     or p_mode not in ('completion', 'batch', 'stream')
+     or p_outcome is null
+     or p_outcome not in ('success', 'http_error', 'network_error', 'cancelled', 'interrupted', 'error')
+     or p_http_status is not null and (p_http_status < 100 or p_http_status > 599)
+     or p_duration_ms is null
+     or p_duration_ms < 0
+     or p_error_code is not null and btrim(p_error_code) = ''
+     or p_model is null
+     or btrim(p_model) = ''
+     or p_input_chars is null
+     or p_input_chars < 0
+     or p_output_chars is null
+     or p_output_chars < 0 then
+    raise exception 'invalid_game_session_ai_attempt' using errcode = '22023';
+  end if;
+
+  -- 先锁并验证 session，禁止把别人的 session 作为写入目标。
+  select gs.user_id
+    into v_session_user_id
+    from public.game_sessions gs
+   where gs.id = p_session_id
+   for update;
+
+  if not found then
+    raise exception 'session_not_found' using errcode = 'P0002';
+  end if;
+
+  if v_session_user_id is distinct from p_user_id then
+    raise exception 'session_user_mismatch' using errcode = '22023';
+  end if;
+
+  select ge.event_id, ge.session_id, ge.user_id, ge.event_type, ge.request_id,
+         ge.attempt, ge.provider, ge.prompt_scope, ge.mode, ge.outcome,
+         ge.http_status, ge.duration_ms, ge.error_code, ge.model,
+         ge.input_chars, ge.output_chars, ge.prompt_tokens, ge.completion_tokens
+    into v_existing_event_id, v_existing_session_id, v_existing_user_id,
+         v_existing_event_type, v_existing_request_id, v_existing_attempt,
+         v_existing_provider, v_existing_prompt_scope, v_existing_mode,
+         v_existing_outcome, v_existing_http_status, v_existing_duration_ms,
+         v_existing_error_code, v_existing_model, v_existing_input_chars,
+         v_existing_output_chars, v_existing_prompt_tokens, v_existing_completion_tokens
+    from public.game_session_events ge
+   where ge.event_id = p_event_id
+   for update;
+
+  if found then
+    -- 同一 event_id 重放：只有字段完全一致才幂等返回，否则视为异常。
+    if v_existing_session_id is distinct from p_session_id
+       or v_existing_user_id is distinct from p_user_id
+       or v_existing_event_type is distinct from 'ai_attempt'
+       or v_existing_request_id is distinct from p_request_id
+       or v_existing_attempt is distinct from p_attempt
+       or v_existing_provider is distinct from p_provider
+       or v_existing_prompt_scope is distinct from p_prompt_scope
+       or v_existing_mode is distinct from p_mode
+       or v_existing_outcome is distinct from p_outcome
+       or v_existing_http_status is distinct from p_http_status
+       or v_existing_duration_ms is distinct from p_duration_ms
+       or v_existing_error_code is distinct from p_error_code
+       or v_existing_model is distinct from p_model
+       or v_existing_input_chars is distinct from p_input_chars
+       or v_existing_output_chars is distinct from p_output_chars
+       or v_existing_prompt_tokens is distinct from p_prompt_tokens
+       or v_existing_completion_tokens is distinct from p_completion_tokens then
+      raise exception 'idempotency_conflict' using errcode = 'P0001';
+    end if;
+
+    return query select p_event_id, true;
+    return;
+  end if;
+
+  insert into public.game_session_events (
+    event_id, session_id, user_id, event_type, request_id, attempt,
+    provider, prompt_scope, mode, outcome, http_status, duration_ms,
+    error_code, model, input_chars, output_chars, prompt_tokens,
+    completion_tokens, created_at
+  ) values (
+    p_event_id, p_session_id, p_user_id, 'ai_attempt', p_request_id, p_attempt,
+    p_provider, p_prompt_scope, p_mode, p_outcome, p_http_status, p_duration_ms,
+    p_error_code, p_model, p_input_chars, p_output_chars,
+    coalesce(p_prompt_tokens, 0), coalesce(p_completion_tokens, 0),
+    now()
+  );
+
+  return query select p_event_id, false;
+end;
+$$;
+
+grant execute on function public.record_game_session_ai_attempt(
+  uuid, uuid, text, text, integer, text, text, text, text, integer,
+  integer, text, text, integer, integer, integer, integer
+) to service_role;


### PR DESCRIPTION
## 这是什么

对应 issue #60：让 Wolfcha 支持**任意 OpenAI 兼容 LLM Provider** 与**多厂商 TTS**，并且**自带 API Key 的玩家不再被强制扣赞助额度**——你自己的 key、你自己的 Base URL，直接玩。

## 做了什么（核心亮点）

1. **自定义 OpenAI 兼容 Provider（BYO Key）**
   - 设置里新增「自定义 OpenAI 兼容 Provider」面板：填 Base URL + API Key（存本地 localStorage），厂商预设覆盖 DeepSeek/Kimi/智谱/MiniMax/StepFun/Grok/Gemini/Claude/OpenRouter/硅基流动/自定义。
   - 新增 `/api/llm-models`：连通性测试（优先 GET `/models` 零消耗，失败回退最小对话请求）+ 拉取模型列表。
   - `/api/chat` 新增 `provider:"custom"` 分支（流式 + 批量），凭据经 `X-Custom-Base-Url`/`X-Custom-Api-Key` 转发。
   - 模型分工：人物生成 / 每日总结 / 复盘每个可指定模型；AI 玩家从所选模型池抽取。

2. **多厂商 TTS**
   - `/api/tts` 从 MiniMax 硬编码重构为适配器注册表：`minimax` / `openai-compatible` / `stepfun` / `volcengine` / `elevenlabs`。
   - 连通性测试 + 音色试听；音色按性别/年龄稳定映射（跨厂商不换声）。

3. **自定义 Key 开局免扣积分（关键修复）**
   - `/api/credits/consume` 识别 `X-Custom-*` 头，自定义端点玩家视为 external source，直接跳过项目积分扣费（不再强制充值）。
   - 前端开局携带自定义 Provider 凭据，`hasActiveExternalModelSource` 纳入自定义 Provider，避免低积分弹窗拦截。
   - 保存 Provider 后**自动激活**（无需手动点"设为使用中"）。

4. **推理模型兼容（修复）**
   - StepFun 等推理模型的 reasoning 会耗尽 `max_tokens` 导致 content 为空：custom 分支自动放大 max_tokens（×3，上限 16384）并默认 `reasoning_effort:"low"`。
   - DB RPC/provider 白名单放行 `custom`；流式无 usage 时 token 归零。

5. **角色进场加速**
   - 新增 `src/lib/template-profiles.ts`：角色基础档案由本地模板库确定性生成（不再消耗一次 LLM 调用），10 人场进场明显加快；persona 仍由 LLM 生成、并发执行。

## 验证

- 本地 `pnpm dev` + 真实 Supabase 项目 + StepFun 自定义端点：登录 → 添加 Provider → 测试连通 → 保存（自动激活）→ 开局 → 夜晚行动 → 天亮发言/TTS 播报，全链路跑通。
- 新增 21 个契约测试（`pnpm test:custom-providers`）+ 既有测试全过；`tsc` 无报错。
- 角色进场实测：模板化基础档案 + persona 并行，10 人场约 1 分钟内进场。

## 注意

- 所有 API Key 仅存用户浏览器 localStorage，服务端只转发、不落盘。
- DB 迁移：`supabase/migrations/20260902000000_*.sql`（provider=custom 放行）和 `20260902010000_*.sql`（RPC 放行 custom + token 归零）。
- `supabase/local-setup-full.sql`：可重复执行的全量 schema 初始化（13 张表 + 全部迁移）。
